### PR TITLE
feat: BROWSE and RECOMMENDATIONS — synthesis and editorial playlists

### DIFF
--- a/provider/__init__.py
+++ b/provider/__init__.py
@@ -39,6 +39,8 @@ SUPPORTED_FEATURES = {
     ProviderFeature.PLAYLIST_TRACKS_EDIT,
     ProviderFeature.PLAYLIST_CREATE,
     ProviderFeature.SIMILAR_TRACKS,
+    ProviderFeature.BROWSE,
+    ProviderFeature.RECOMMENDATIONS,
 }
 
 

--- a/provider/api_client.py
+++ b/provider/api_client.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Sequence
 from typing import Any, ParamSpec, TypeVar, cast
 
 from music_assistant_models.errors import (
@@ -17,6 +17,7 @@ from zvuk_music import CollectionItem as ZvukCollectionItem
 from zvuk_music import Playlist as ZvukPlaylist
 from zvuk_music import Release as ZvukRelease
 from zvuk_music import Search as ZvukSearch
+from zvuk_music import SimplePlaylist as ZvukSimplePlaylist
 from zvuk_music import SimpleTrack as ZvukSimpleTrack
 from zvuk_music import Stream as ZvukStream
 from zvuk_music import Track as ZvukTrack
@@ -349,6 +350,42 @@ class ZvukMusicClient:
         """
         client = self._ensure_connected()
         return await client.get_user_playlists()
+
+    @handle_zvuk_errors(not_found_return=[])
+    async def get_short_playlists(
+        self, playlist_ids: Sequence[int | str]
+    ) -> list[ZvukSimplePlaylist]:
+        """Get playlist metadata (title, image, description) by IDs without tracks.
+
+        Uses the lightweight getShortPlaylist GraphQL query which returns only metadata.
+        Works for both regular playlists and synthesis playlists (IDs 3,4,6,11,12,13,14,15).
+
+        :param playlist_ids: List of playlist IDs.
+        :return: List of SimplePlaylist objects.
+        """
+        client = self._ensure_connected()
+        return await client.get_short_playlist(list(playlist_ids))
+
+    @handle_zvuk_errors(not_found_return=[])
+    async def get_editorial_playlist_ids(self) -> list[int]:
+        """Get editorial (curated) playlist IDs from Zvuk's grid content API.
+
+        Fetches «Подборки» — genre-focused curated playlists shown on the home page.
+
+        :return: List of playlist IDs.
+        """
+        client = self._ensure_connected()
+        result = await client._request.get(
+            f"{TINY_API_URL}/grid/content",
+            params={"name": "editorial_playlist", "ranker_enabled": "true"},
+        )
+        if not result:
+            return []
+        meta = result.get("meta", [])
+        for item in meta:
+            if item.get("type") == "playlist":
+                return [int(pid) for pid in item.get("ids", [])]
+        return []
 
     # Library modifications
 

--- a/provider/constants.py
+++ b/provider/constants.py
@@ -24,3 +24,7 @@ IMAGE_SIZE_LARGE: Final[int] = 600
 
 # URLs
 ZVUK_BASE_URL: Final[str] = "https://zvuk.com"
+
+# Synthesis (personalized) playlist IDs — «Плейлисты для вас» on the home page.
+# These AI-generated playlists are identified by low fixed IDs, stable per account.
+SYNTHESIS_PLAYLIST_IDS: Final[list[int]] = [3, 4, 6, 11, 12, 13, 14, 15]

--- a/provider/provider.py
+++ b/provider/provider.py
@@ -18,6 +18,7 @@ from music_assistant_models.media_items import (
     ItemMapping,
     MediaItemType,
     Playlist,
+    RecommendationFolder,
     SearchResults,
     Track,
 )
@@ -33,6 +34,7 @@ from .constants import (
     DEFAULT_LIMIT,
     PLAYLIST_TRACKS_PAGE_SIZE,
     QUALITY_LOSSLESS,
+    SYNTHESIS_PLAYLIST_IDS,
 )
 from .parsers import parse_album, parse_artist, parse_playlist, parse_track
 
@@ -383,7 +385,11 @@ class ZvukMusicProvider(MusicProvider):
                     self.logger.debug("Error parsing library track: %s", err)
 
     async def get_library_playlists(self) -> AsyncGenerator[Playlist, None]:
-        """Retrieve library playlists from Zvuk Music."""
+        """Retrieve library playlists from Zvuk Music.
+
+        Yields user's own playlists followed by Zvuk's personalized synthesis
+        playlists («Плейлисты для вас»: IDs 3, 4, 6, 11, 12, 13, 14, 15).
+        """
         collection_items = await self.client.get_user_playlists()
         if not collection_items:
             return
@@ -397,6 +403,68 @@ class ZvukMusicProvider(MusicProvider):
                     yield parse_playlist(self, playlist)
                 except InvalidDataError as err:
                     self.logger.debug("Error parsing library playlist: %s", err)
+
+        # Synthesis playlists — personalized AI playlists («Плейлисты для вас»)
+        synthesis_playlists = await self.client.get_short_playlists(SYNTHESIS_PLAYLIST_IDS)
+        for simple_pl in synthesis_playlists:
+            try:
+                yield parse_playlist(self, simple_pl)
+            except InvalidDataError as err:
+                self.logger.debug("Error parsing synthesis playlist: %s", err)
+
+    async def recommendations(self) -> list[RecommendationFolder]:
+        """Return personalized and editorial playlist recommendations.
+
+        Returns two folders:
+        - «Плейлисты для вас»: Zvuk's AI-generated personalized playlists.
+        - «Подборки»: Editorial genre-themed curated playlists.
+        """
+        folders: list[RecommendationFolder] = []
+
+        # Folder 1: Personalized synthesis playlists («Плейлисты для вас»)
+        synthesis_playlists = await self.client.get_short_playlists(SYNTHESIS_PLAYLIST_IDS)
+        for_you_items: list[Playlist] = []
+        for simple_pl in synthesis_playlists:
+            try:
+                for_you_items.append(parse_playlist(self, simple_pl))
+            except InvalidDataError as err:
+                self.logger.debug("Error parsing synthesis playlist: %s", err)
+        if for_you_items:
+            folders.append(
+                RecommendationFolder(
+                    item_id="for_you",
+                    provider=self.instance_id,
+                    name="Плейлисты для вас",
+                    subtitle="Персональные плейлисты от Звук",
+                    icon="mdi-playlist-music",
+                    items=for_you_items,  # type: ignore[arg-type]
+                )
+            )
+
+        # Folder 2: Editorial curated playlists («Подборки»)
+        editorial_ids = await self.client.get_editorial_playlist_ids()
+        if editorial_ids:
+            editorial_str_ids = [str(pid) for pid in editorial_ids[:DEFAULT_LIMIT]]
+            editorial_playlists = await self.client.get_playlists(editorial_str_ids)
+            editorial_items: list[Playlist] = []
+            for full_pl in editorial_playlists:
+                try:
+                    editorial_items.append(parse_playlist(self, full_pl))
+                except InvalidDataError as err:
+                    self.logger.debug("Error parsing editorial playlist: %s", err)
+            if editorial_items:
+                folders.append(
+                    RecommendationFolder(
+                        item_id="editorial",
+                        provider=self.instance_id,
+                        name="Подборки",
+                        subtitle="Плейлисты от редакции Звук по жанрам",
+                        icon="mdi-music-box-multiple",
+                        items=editorial_items,  # type: ignore[arg-type]
+                    )
+                )
+
+        return folders
 
     # Library edit methods
 
@@ -502,12 +570,15 @@ class ZvukMusicProvider(MusicProvider):
         quality_pref = self.config.get_value(CONF_QUALITY)
         quality_str = str(quality_pref) if quality_pref is not None else QUALITY_LOSSLESS
 
-        # Fetch track metadata for duration.
+        # Fetch track metadata for duration and FLAC availability.
         track = await self.client.get_track(item_id)
         duration: int | None = None
+        has_flac: bool = True  # default: always attempt FLAC; field is unreliable
         if track is not None:
             if getattr(track, "duration", None) is not None:
                 duration = int(track.duration)
+            if getattr(track, "has_flac", None) is not None:
+                has_flac = bool(track.has_flac)
 
         # Build quality fallback chain.
         # /api/tiny/track/stream quality strings: "flac", "high", "mid"

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -13,6 +13,7 @@ from music_assistant.providers.zvuk_music.parsers import (
     parse_playlist,
     parse_track,
 )
+from provider.constants import SYNTHESIS_PLAYLIST_IDS
 
 
 def _create_mock_image(template: str = "https://zvuk.com/image/{width}x{height}") -> Mock:
@@ -701,3 +702,57 @@ class TestParsePlaylist:
 
         assert result.name == "Playlist No Cover"
         assert result.metadata.images is None or len(result.metadata.images) == 0
+
+    def test_parse_playlist_simple_playlist_no_user_id(self, mock_provider: Mock) -> None:
+        """Test that SimplePlaylist (no user_id) is parsed as not editable.
+
+        Synthesis playlists (IDs 3,4,6,11,12,13,14,15) are returned as SimplePlaylist
+        objects by get_short_playlist() — they have no user_id attribute.
+        """
+        playlist_obj = _create_mock_playlist(
+            playlist_id=3,  # synthesis playlist ID
+            title="Свежие релизы",
+            description="Только в вашем вкусе",
+            user_id=None,  # SimplePlaylist: no user_id
+        )
+
+        result = parse_playlist(mock_provider, playlist_obj)
+
+        assert result.name == "Свежие релизы"
+        assert result.metadata.description == "Только в вашем вкусе"
+        assert result.is_editable is False
+
+    def test_parse_playlist_simple_playlist_with_image(self, mock_provider: Mock) -> None:
+        """Test that SimplePlaylist with image URL is parsed correctly."""
+        image = Mock()
+        image.src = "https://obs-image-service.example.com/abc123"
+        image.get_url = Mock(return_value="https://zvuk.com/synthesis/600x600.jpg")
+
+        playlist_obj = _create_mock_playlist(
+            playlist_id=6,
+            title="Когда хочется музыки",
+            description="У тишины нет шансов",  # noqa: RUF001
+            user_id=None,
+            image=image,
+        )
+
+        result = parse_playlist(mock_provider, playlist_obj)
+
+        assert result.name == "Когда хочется музыки"
+        assert result.is_editable is False
+        # Image should be mapped
+        assert result.metadata.images is not None
+        assert len(result.metadata.images) == 1
+
+    def test_parse_playlist_synthesis_ids_treated_as_not_editable(
+        self, mock_provider: Mock
+    ) -> None:
+        """Verify all synthesis playlist IDs (3,4,6,11,12,13,14,15) parse as not editable."""
+        for pid in SYNTHESIS_PLAYLIST_IDS:
+            playlist_obj = _create_mock_playlist(
+                playlist_id=pid,
+                title=f"Playlist {pid}",
+                user_id=None,  # SimplePlaylist has no user_id
+            )
+            result = parse_playlist(mock_provider, playlist_obj)
+            assert result.is_editable is False, f"Playlist {pid} should not be editable"


### PR DESCRIPTION
## Summary

Implements `ProviderFeature.BROWSE` and `ProviderFeature.RECOMMENDATIONS` to expose Zvuk's personalized and editorial playlists in Music Assistant.

## Changes

### New features
- **Synthesis playlists in library**: «Плейлисты для вас» (IDs 3,4,6,11,12,13,14,15) now appear in the Playlists library section, fetched via the lightweight `getShortPlaylist` GraphQL query.
- **Recommendations**: Two folders exposed via `recommendations()` method:
  - *«Плейлисты для вас»* — AI-generated personalized playlists
  - *«Подборки»* — editorial genre-themed curated playlists (fetched from `/api/tiny/grid/content?name=editorial_playlist`)
- **Browse support**: `ProviderFeature.BROWSE` enabled — MA's default `browse()` automatically surfaces the recommendations section.

### API additions (`api_client.py`)
- `get_short_playlists(playlist_ids)` — wraps `client.get_short_playlist()`, returns `SimplePlaylist` metadata
- `get_editorial_playlist_ids()` — HTTP GET to Zvuk grid content API, returns up to 20 editorial playlist IDs

### Bug fixes
- Fix undefined `has_flac` variable in `get_stream_details()` (used in debug log and quality chain)

### Tests
- 3 new tests for synthesis playlist parsing via `SimplePlaylist` (no `user_id` → `is_editable=False`)
- All 52 tests pass, all lints clean

## API explored
- Synthesis playlists: stable personalized AI playlists, IDs fixed per Zvuk account
- Editorial playlists: `GET /api/tiny/grid/content?name=editorial_playlist` → 20 curated genre playlists
- Both work with existing `parse_playlist()` which already handles `SimplePlaylist` via `hasattr()` checks