### PR TITLE
feat: LYRICS — synchronized lyrics via /api/tiny/lyrics

### DIFF
--- a/provider/__init__.py
+++ b/provider/__init__.py
@@ -41,6 +41,8 @@ SUPPORTED_FEATURES = {
     ProviderFeature.SIMILAR_TRACKS,
     ProviderFeature.BROWSE,
     ProviderFeature.RECOMMENDATIONS,
+    ProviderFeature.LYRICS,
+    ProviderFeature.TRACK_METADATA,
 }
 
 

--- a/provider/api_client.py
+++ b/provider/api_client.py
@@ -387,6 +387,27 @@ class ZvukMusicClient:
                 return [int(pid) for pid in item.get("ids", [])]
         return []
 
+    @handle_zvuk_errors(not_found_return=None)
+    async def get_lyrics(self, track_id: str) -> dict[str, str | None] | None:
+        """Get lyrics for a track from Zvuk lyrics API.
+
+        Fetches lyrics from ``/api/tiny/lyrics?track_id={id}``.
+        Returns synced LRC text (type ``'subtitle'``) or plain text (type ``'lyrics'``).
+        Returns ``None`` if the track has no lyrics.
+
+        :param track_id: Track ID.
+        :return: Dict with ``lyrics`` (str or None), ``type`` (str or None),
+            ``translation`` (str or None), or None on error.
+        """
+        client = self._ensure_connected()
+        result = await client._request.get(
+            f"{TINY_API_URL}/lyrics",
+            params={"track_id": track_id},
+        )
+        if not result or not result.get("lyrics"):
+            return None
+        return result
+
     # Library modifications
 
     async def like_track(self, track_id: str) -> bool:

--- a/provider/provider.py
+++ b/provider/provider.py
@@ -16,6 +16,7 @@ from music_assistant_models.media_items import (
     Artist,
     AudioFormat,
     ItemMapping,
+    MediaItemMetadata,
     MediaItemType,
     Playlist,
     RecommendationFolder,
@@ -465,6 +466,34 @@ class ZvukMusicProvider(MusicProvider):
                 )
 
         return folders
+
+    async def get_track_metadata(self, track: Track) -> MediaItemMetadata | None:
+        """Fetch lyrics for a track from Zvuk's lyrics API.
+
+        Called by MA when ``ProviderFeature.TRACK_METADATA`` is declared.
+        Returns LRC-synced lyrics (``lrc_lyrics``) when the API returns type
+        ``'subtitle'``, otherwise plain text (``lyrics``). Returns ``None`` if
+        the track has no lyrics or the API call fails.
+
+        :param track: The MA Track object. ``item_id`` is used to call the API.
+        :return: MediaItemMetadata with lyrics, or None.
+        """
+        track_id = track.item_id
+        result = await self.client.get_lyrics(track_id)
+        if not result:
+            return None
+
+        lyrics_text: str = result.get("lyrics") or ""
+        lyrics_type: str = result.get("type") or ""
+        if not lyrics_text:
+            return None
+
+        metadata = MediaItemMetadata()
+        if lyrics_type == "subtitle":
+            metadata.lrc_lyrics = lyrics_text
+        else:
+            metadata.lyrics = lyrics_text
+        return metadata
 
     # Library edit methods
 

--- a/tests/test_lyrics.py
+++ b/tests/test_lyrics.py
@@ -1,0 +1,83 @@
+"""Tests for Zvuk Music lyrics feature (get_track_metadata)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, Mock
+
+import pytest
+
+from provider.provider import ZvukMusicProvider
+
+
+def _make_provider(lyrics_result: dict[str, str | None] | None) -> ZvukMusicProvider:
+    """Create a ZvukMusicProvider mock with a preset lyrics result."""
+    provider = Mock(spec=ZvukMusicProvider)
+    provider.client = Mock()
+    provider.client.get_lyrics = AsyncMock(return_value=lyrics_result)
+    provider.get_track_metadata = ZvukMusicProvider.get_track_metadata.__get__(
+        provider, ZvukMusicProvider
+    )
+    return provider
+
+
+def _make_track(item_id: str = "173663389") -> Mock:
+    """Create a minimal MA Track mock."""
+    track = MagicMock()
+    track.item_id = item_id
+    return track
+
+
+class TestGetTrackMetadata:
+    """Tests for ZvukMusicProvider.get_track_metadata()."""
+
+    @pytest.mark.asyncio
+    async def test_synced_lyrics_returned_as_lrc(self) -> None:
+        """LRC synced lyrics (type='subtitle') go into metadata.lrc_lyrics."""
+        lrc_text = "[00:00.68]Честное слово мы с тобой лишние\n[00:04.71]В мире весёлых сетей\n"  # noqa: RUF001
+        provider = _make_provider({"lyrics": lrc_text, "type": "subtitle", "translation": None})
+
+        result = await provider.get_track_metadata(_make_track("173663389"))
+
+        assert result is not None
+        assert result.lrc_lyrics == lrc_text
+        assert result.lyrics is None
+
+    @pytest.mark.asyncio
+    async def test_plain_lyrics_returned_as_lyrics(self) -> None:
+        """Plain lyrics (type='lyrics') go into metadata.lyrics."""
+        plain_text = "Some plain lyrics text\nSecond line\n"
+        provider = _make_provider({"lyrics": plain_text, "type": "lyrics", "translation": None})
+
+        result = await provider.get_track_metadata(_make_track("99999"))
+
+        assert result is not None
+        assert result.lyrics == plain_text
+        assert result.lrc_lyrics is None
+
+    @pytest.mark.asyncio
+    async def test_no_lyrics_returns_none(self) -> None:
+        """When API returns None (track has no lyrics), return None."""
+        provider = _make_provider(None)
+
+        result = await provider.get_track_metadata(_make_track("174649396"))
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_empty_lyrics_text_returns_none(self) -> None:
+        """When API returns result with empty/null lyrics text, return None."""
+        provider = _make_provider({"lyrics": None, "type": "subtitle", "translation": None})
+
+        result = await provider.get_track_metadata(_make_track("999"))
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_correct_track_id_passed_to_client(self) -> None:
+        """The correct track item_id is forwarded to the API client."""
+        provider = _make_provider(None)
+        track = _make_track("12345678")
+
+        await provider.get_track_metadata(track)
+
+        provider.client.get_lyrics.assert_awaited_once_with("12345678")  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary

Implements `ProviderFeature.LYRICS` and `ProviderFeature.TRACK_METADATA` to fetch synchronized lyrics from Zvuk's native lyrics API.

## API

```
GET /api/tiny/lyrics?track_id={id}
→ {"lyrics": "[00:00.68]текст\n[00:04.71]...", "type": "subtitle", "translation": null}
```

- **`type: "subtitle"`** — synchronized LRC format с `[MM:SS.mm]` timestamps → `metadata.lrc_lyrics`
- **`type: "lyrics"`** — plain text → `metadata.lyrics`
- Returns `lyrics: null` для треков без текста (обрабатывается gracefully)

## Changes

### `provider/api_client.py`
- New `get_lyrics(track_id)`: GET /api/tiny/lyrics?track_id={id}, returns None if no lyrics

### `provider/provider.py`
- New `get_track_metadata(track)`: fetches lyrics, wraps in MediaItemMetadata
- Added MediaItemMetadata to imports

### `provider/__init__.py`
- Added ProviderFeature.LYRICS and ProviderFeature.TRACK_METADATA to SUPPORTED_FEATURES

### `tests/test_lyrics.py` (new)
- 5 unit tests covering all cases

## Tests
57 passed, all lints and mypy clean.