### PR TITLE
fix: resolve static playlist cover images via auth cookie

### DIFF
--- a/provider/parsers.py
+++ b/provider/parsers.py
@@ -328,13 +328,17 @@ def parse_playlist(
     if playlist_obj.image:
         image_url = _get_image_url(playlist_obj.image)
         if image_url:
+            # Static avatar images (/static/avatar/...) require Zvuk auth cookies and
+            # cannot be fetched publicly; set remotely_accessible=False so MA calls
+            # resolve_image() on the provider instead of trying to proxy the URL directly.
+            remotely_accessible = not playlist_obj.image.src.startswith("/static/")
             playlist.metadata.images = UniqueList(
                 [
                     MediaItemImage(
                         type=ImageType.THUMB,
                         path=image_url,
                         provider=provider.instance_id,
-                        remotely_accessible=True,
+                        remotely_accessible=remotely_accessible,
                     )
                 ]
             )

--- a/provider/provider.py
+++ b/provider/provider.py
@@ -495,6 +495,25 @@ class ZvukMusicProvider(MusicProvider):
             metadata.lyrics = lyrics_text
         return metadata
 
+    async def resolve_image(self, path: str) -> str | bytes:
+        """Fetch a Zvuk static playlist image with authentication.
+
+        Called by MA when a ``MediaItemImage`` has ``remotely_accessible=False``.
+        Static playlist avatar images (``/static/avatar/playlist/...``) require
+        Zvuk auth cookies and cannot be fetched anonymously.
+
+        :param path: Full image URL (e.g. ``https://zvuk.com/static/avatar/...``).
+        :return: Raw image bytes on success, original URL string as fallback.
+        """
+        token = self.config.get_value(CONF_TOKEN)
+        try:
+            async with self.mass.http_session.get(path, cookies={"auth": str(token)}) as resp:
+                if resp.status == 200:
+                    return await resp.read()
+        except Exception as err:
+            self.logger.debug("Failed to resolve static image %s: %s", path, err)
+        return path
+
     # Library edit methods
 
     async def library_add(self, item: MediaItemType) -> bool:


### PR DESCRIPTION
## Problem

Editorial («Подборки») and synthesis («Плейлисты для вас») playlists were showing without cover images in the MA discovery/recommendations section.

**Root cause**: These playlists use images hosted at `/static/avatar/playlist/...` on zvuk.com. Unlike CDN images, static avatars return HTTP 418 (bot detection) when fetched without Zvuk auth cookies. MA's imageproxy was trying to fetch them anonymously → 404.

## Fix

- **`parsers.py`**: In `parse_playlist()`, detect if `image.src` starts with `/static/` and set `remotely_accessible=False`. This tells MA to call `resolve_image()` on the provider instead of proxying the URL directly.
- **`provider.py`**: Implement `resolve_image()` which fetches the static image with the configured auth token as a cookie (`{"auth": token}`), returning raw image bytes on success or the original URL as fallback.

## Testing

- 57 tests passing, all lints/mypy clean
- Manual: after restarting MA, editorial playlist covers should appear in Recommendations → Подборки