### PR TITLE
fix: update get_editorial_playlist_ids() for changed API response shape

### DIFF
--- a/provider/api_client.py
+++ b/provider/api_client.py
@@ -381,11 +381,9 @@ class ZvukMusicClient:
         )
         if not result:
             return []
-        meta = result.get("meta", [])
-        for item in meta:
-            if item.get("type") == "playlist":
-                return [int(pid) for pid in item.get("ids", [])]
-        return []
+        # Response: {'page': {'data': [{'type': 'playlist', 'id': 123}, ...]}, ...}
+        data = result.get("page", {}).get("data", [])
+        return [int(item["id"]) for item in data if item.get("type") == "playlist"]
 
     @handle_zvuk_errors(not_found_return=None)
     async def get_lyrics(self, track_id: str) -> dict[str, str | None] | None:


### PR DESCRIPTION
## Problem

«Подборки» (editorial playlists) showed no covers and no items in Recommendations.

**Root cause**: The `/api/tiny/grid/content` endpoint response structure changed:
- **Old**: `{'meta': [{'type': 'playlist', 'ids': [123, 456, ...]}]}`
- **New**: `{'page': {'data': [{'type': 'playlist', 'id': 123}, ...]}}`

`get_editorial_playlist_ids()` was looking at `result['meta']` and always returned `[]`, so no editorial playlists were ever fetched.

## Fix

Updated parser to use the new response shape: `result['page']['data']` with individual `id` fields per item.

## Testing

- 57 tests passing, all lints/mypy clean
- After restart: Recommendations → Подборки should now show playlists with covers