### PR TITLE
fix: use browser headers in resolve_image() for static Zvuk URLs

### DIFF
--- a/provider/provider.py
+++ b/provider/provider.py
@@ -507,7 +507,19 @@ class ZvukMusicProvider(MusicProvider):
         """
         token = self.config.get_value(CONF_TOKEN)
         try:
-            async with self.mass.http_session.get(path, cookies={"auth": str(token)}) as resp:
+            async with self.mass.http_session.get(
+                path,
+                headers={
+                    "X-Auth-Token": str(token),
+                    "User-Agent": (
+                        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                        "AppleWebKit/537.36 (KHTML, like Gecko) "
+                        "Chrome/120.0.0.0 Safari/537.36"
+                    ),
+                    "Referer": "https://zvuk.com/",
+                    "Origin": "https://zvuk.com",
+                },
+            ) as resp:
                 if resp.status == 200:
                     return await resp.read()
         except Exception as err:


### PR DESCRIPTION
## Problem

`resolve_image()` was sending either a cookie or just `X-Auth-Token` header when fetching `https://zvuk.com/static/avatar/playlist/...` images. Both return HTTP 418 (bot detection).

## Root cause

Zvuk's static file CDN requires browser-like headers:
- `User-Agent`: must look like a real browser
- `Referer: https://zvuk.com/`
- `Origin: https://zvuk.com`
- `X-Auth-Token`: the API token

Without all four, the CDN returns 418 and the imageproxy returns 404.

Confirmed working with `curl`:
```
curl -H 'X-Auth-Token: ...' -H 'User-Agent: Mozilla/5.0...' -H 'Referer: https://zvuk.com/' -> 200
```

## Fix

Updated `resolve_image()` to send the same UA/Referer/Origin headers that the `zvuk_music.ClientAsync` uses internally.

## Testing

- 57 tests passing, all lints/mypy clean