### PR TITLE
fix: always try FLAC first when lossless quality is requested

### DIFF
--- a/provider/provider.py
+++ b/provider/provider.py
@@ -648,7 +648,7 @@ class ZvukMusicProvider(MusicProvider):
             quality_str,
             has_flac,
         )
-        if quality_str == QUALITY_LOSSLESS and has_flac:
+        if quality_str == QUALITY_LOSSLESS:
             quality_chain = [
                 ("flac", ContentType.FLAC, 0),
                 ("high", ContentType.MP3, 320),


### PR DESCRIPTION
## Problem

CI failed: `test_lossless_always_tries_flac_first` — expected `ContentType.FLAC` but got `ContentType.MP3`.

The condition `if quality_str == QUALITY_LOSSLESS and has_flac:` skipped FLAC when `has_flac=False`, even though the API may still return a FLAC stream URL.

## Fix

Remove `and has_flac` guard. When lossless is preferred, always try FLAC first and fall back to HIGH→MID if the API returns None. The `has_flac` field was already documented as unreliable and defaulted to `True`.

## Testing

- 57 tests passing (including `test_lossless_always_tries_flac_first`), all lints/mypy clean