### PR TITLE
fix(tests): use cast to avoid type: ignore in test_lyrics

### DIFF
--- a/tests/test_lyrics.py
+++ b/tests/test_lyrics.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock, Mock
 
 import pytest
@@ -80,4 +81,4 @@ class TestGetTrackMetadata:
 
         await provider.get_track_metadata(track)
 
-        provider.client.get_lyrics.assert_awaited_once_with("12345678")  # type: ignore[attr-defined]
+        cast("AsyncMock", provider.client.get_lyrics).assert_awaited_once_with("12345678")


### PR DESCRIPTION
## Problem
Upstream CI reported two failures:
- `Ruff I001` (unsorted-imports) in `test_lyrics.py` and `test_parsers.py`
- `mypy unused-ignore` — upstream uses `follow_imports=silent` so it doesn't see the `attr-defined` error, making the `# type: ignore[attr-defined]` comment unused

## Fix
- Sort imports (ruff auto-fix applied)
- Replace `# type: ignore[attr-defined]` with `cast("AsyncMock", ...)` — satisfies both local mypy (full import following) and upstream mypy (silent following)