### PR TITLE
fix(tests): use music_assistant imports + upstream CI script

### DIFF
--- a/provider/provider.py
+++ b/provider/provider.py
@@ -521,10 +521,10 @@ class ZvukMusicProvider(MusicProvider):
                 },
             ) as resp:
                 if resp.status == 200:
-                    return await resp.read()
+                    return bytes(await resp.read())
         except Exception as err:
             self.logger.debug("Failed to resolve static image %s: %s", path, err)
-        return path
+        return str(path)
 
     # Library edit methods
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,6 +183,14 @@ no_implicit_optional = true
 no_implicit_reexport = true
 packages = ["tests", "provider"]
 show_error_codes = true
+
+# provider.py subclasses MusicProvider and uses use_cache (untyped decorator) from ma-server;
+# relax rules that trip on third-party base class typing
+[[tool.mypy.overrides]]
+module = "provider.provider"
+disallow_subclassing_any = false
+disallow_untyped_decorators = false
+no_any_return = false
 strict_equality = true
 strict_optional = true
 warn_incomplete_stub = true

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -18,9 +18,29 @@ source "$REPO_ROOT/$env_name/bin/activate"
 
 
 # Install upstream MA server + provider in editable mode
-uv pip install \
-  "git+https://github.com/music-assistant/server.git@dev" \
-  -e "$REPO_ROOT/.[test]"
+MA_SERVER_DIR="${MA_SERVER_DIR:-$HOME/Projects/ma-server}"
+
+if [[ -d "$MA_SERVER_DIR" ]]; then
+  echo "Installing ma-server from local clone: $MA_SERVER_DIR"
+  # Sync provider source into ma-server before installing
+  rsync -a --delete \
+    --include="*.py" --include="manifest.json" \
+    --exclude="__pycache__/" --exclude="*.pyc" \
+    "$REPO_ROOT/provider/" "$MA_SERVER_DIR/music_assistant/providers/zvuk_music/"
+  # 1) Install ma-server from local clone (includes test extras + requirements)
+  uv pip install -e "$MA_SERVER_DIR/.[test]" -r "$MA_SERVER_DIR/requirements_all.txt"
+  # 2) Install our provider's test extras only (no-deps avoids reinstalling ma-server from git)
+  uv pip install -e "$REPO_ROOT/.[test]" --no-deps
+  # 3) Remove any stale music_assistant namespace packages from site-packages
+  #    (editable install uses finder; leftover site-packages shadow the editable path)
+  SITE_PKG=$(python -c "import sysconfig; print(sysconfig.get_path('platlib'))")
+  rm -rf "$SITE_PKG/music_assistant"
+else
+  echo "Local ma-server not found, installing from git (may be stale)"
+  uv pip install \
+    "git+https://github.com/music-assistant/server.git@dev" \
+    -e "$REPO_ROOT/.[test]"
+fi
 
 
 # Set up pre-commit hooks if available

--- a/scripts/test-upstream.sh
+++ b/scripts/test-upstream.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Reproduce upstream CI environment locally.
+#
+# What it does:
+#   1. Uses the local ma-server clone (~/Projects/ma-server, upstream/zvuk_music branch)
+#   2. Copies provider files into ma-server's zvuk_music provider directory
+#   3. Creates an isolated venv in ma-server, installs .[test] + requirements_all.txt
+#   4. Runs pre-commit (like CI lint job) and pytest (like CI test job)
+#
+# Usage:
+#   ./scripts/test-upstream.sh              # lint + test
+#   ./scripts/test-upstream.sh --lint-only  # pre-commit only
+#   ./scripts/test-upstream.sh --test-only  # pytest only
+set -euo pipefail
+
+MA_SERVER="${MA_SERVER_DIR:-$HOME/Projects/ma-server}"
+PROVIDER_SRC="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/provider"
+VENV="$MA_SERVER/.venv-ci"
+
+MODE="${1:-}"
+
+# ── Verify prerequisites ────────────────────────────────────────────────────
+if [[ ! -d "$MA_SERVER" ]]; then
+  echo "ERROR: ma-server not found at $MA_SERVER"
+  echo "       Set MA_SERVER_DIR env var to override."
+  exit 1
+fi
+
+BRANCH=$(git -C "$MA_SERVER" branch --show-current)
+echo "▶ ma-server branch: $BRANCH"
+echo "▶ provider source:  $PROVIDER_SRC"
+
+# ── Sync provider files into ma-server ─────────────────────────────────────
+DEST="$MA_SERVER/music_assistant/providers/zvuk_music"
+echo "▶ Syncing provider → $DEST"
+rsync -a --delete \
+  --include="*.py" --include="manifest.json" \
+  --exclude="__pycache__/" --exclude="*.pyc" \
+  "$PROVIDER_SRC/" "$DEST/"
+
+# ── Sync test files ─────────────────────────────────────────────────────────
+TEST_SRC="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/tests"
+TEST_DEST="$MA_SERVER/tests/providers/zvuk_music"
+mkdir -p "$TEST_DEST"
+echo "▶ Syncing tests → $TEST_DEST"
+rsync -a --delete \
+  --include="*.py" --exclude="e2e/" --exclude="__pycache__/" --exclude="*.pyc" \
+  "$TEST_SRC/" "$TEST_DEST/"
+
+# ── Create / update venv ────────────────────────────────────────────────────
+if [[ ! -d "$VENV" ]]; then
+  echo "▶ Creating venv at $VENV"
+  uv venv --python 3.12 "$VENV"
+fi
+
+echo "▶ Installing dependencies (uv pip install . .[test] -r requirements_all.txt)"
+uv pip install --python "$VENV/bin/python" \
+  "$MA_SERVER/.[test]" \
+  -r "$MA_SERVER/requirements_all.txt" \
+  --quiet
+
+# ── Run pre-commit ───────────────────────────────────────────────────────────
+if [[ "$MODE" != "--test-only" ]]; then
+  echo ""
+  echo "══════════════════════════════════════════"
+  echo "  pre-commit (lint)"
+  echo "══════════════════════════════════════════"
+  cd "$MA_SERVER"
+  SKIP=no-commit-to-branch \
+    "$VENV/bin/python" -m pre_commit run --all-files || true
+fi
+
+# ── Run pytest ───────────────────────────────────────────────────────────────
+if [[ "$MODE" != "--lint-only" ]]; then
+  echo ""
+  echo "══════════════════════════════════════════"
+  echo "  pytest"
+  echo "══════════════════════════════════════════"
+  cd "$MA_SERVER"
+  "$VENV/bin/python" -m pytest \
+    --durations 10 \
+    --cov=music_assistant \
+    --cov-report=term-missing \
+    tests/providers/zvuk_music/ \
+    -v
+fi

--- a/tests/test_lyrics.py
+++ b/tests/test_lyrics.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, Mock
 
 import pytest
 
-from provider.provider import ZvukMusicProvider
+from music_assistant.providers.zvuk_music.provider import ZvukMusicProvider
 
 
 def _make_provider(lyrics_result: dict[str, str | None] | None) -> ZvukMusicProvider:

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -7,13 +7,13 @@ from unittest.mock import Mock
 import pytest
 from music_assistant_models.enums import AlbumType, ImageType
 
+from music_assistant.providers.zvuk_music.constants import SYNTHESIS_PLAYLIST_IDS
 from music_assistant.providers.zvuk_music.parsers import (
     parse_album,
     parse_artist,
     parse_playlist,
     parse_track,
 )
-from provider.constants import SYNTHESIS_PLAYLIST_IDS
 
 
 def _create_mock_image(template: str = "https://zvuk.com/image/{width}x{height}") -> Mock:


### PR DESCRIPTION
## Problem
Tests imported `from provider.*` which works locally but fails in upstream CI (`ModuleNotFoundError: No module named 'provider'`).

## Changes
- **test_parsers.py / test_lyrics.py**: Replace `from provider.*` with `from music_assistant.providers.zvuk_music.*` (matches upstream structure)
- **scripts/setup.sh**: Install from local ma-server clone when available; remove stale site-packages that shadow editable install
- **scripts/test-upstream.sh**: New script to reproduce upstream CI locally (syncs files, installs in isolated venv, runs pre-commit + pytest)
- **pyproject.toml**: Add mypy overrides for provider.provider to relax rules that trip on ma-server base class typing
- **provider/provider.py**: Explicit `bytes()`/`str()` casts in `resolve_image()` to satisfy mypy