### PR TITLE
fix: address PR #3242 Copilot review comments

### DIFF
--- a/provider/api_client.py
+++ b/provider/api_client.py
@@ -383,7 +383,18 @@ class ZvukMusicClient:
             return []
         # Response: {'page': {'data': [{'type': 'playlist', 'id': 123}, ...]}, ...}
         data = result.get("page", {}).get("data", [])
-        return [int(item["id"]) for item in data if item.get("type") == "playlist"]
+        playlist_ids: list[int] = []
+        for item in data:
+            if item.get("type") != "playlist":
+                continue
+            raw_id = item.get("id")
+            if raw_id is None:
+                continue
+            try:
+                playlist_ids.append(int(raw_id))
+            except (TypeError, ValueError):
+                continue
+        return playlist_ids
 
     @handle_zvuk_errors(not_found_return=None)
     async def get_lyrics(self, track_id: str) -> dict[str, str | None] | None:

--- a/provider/constants.py
+++ b/provider/constants.py
@@ -27,4 +27,4 @@ ZVUK_BASE_URL: Final[str] = "https://zvuk.com"
 
 # Synthesis (personalized) playlist IDs — «Плейлисты для вас» on the home page.
 # These AI-generated playlists are identified by low fixed IDs, stable per account.
-SYNTHESIS_PLAYLIST_IDS: Final[list[int]] = [3, 4, 6, 11, 12, 13, 14, 15]
+SYNTHESIS_PLAYLIST_IDS: Final[tuple[int, ...]] = (3, 4, 6, 11, 12, 13, 14, 15)

--- a/provider/parsers.py
+++ b/provider/parsers.py
@@ -331,7 +331,7 @@ def parse_playlist(
             # Static avatar images (/static/avatar/...) require Zvuk auth cookies and
             # cannot be fetched publicly; set remotely_accessible=False so MA calls
             # resolve_image() on the provider instead of trying to proxy the URL directly.
-            remotely_accessible = not playlist_obj.image.src.startswith("/static/")
+            remotely_accessible = "/static/" not in (getattr(playlist_obj.image, "src", "") or "")
             playlist.metadata.images = UniqueList(
                 [
                     MediaItemImage(

--- a/provider/provider.py
+++ b/provider/provider.py
@@ -473,13 +473,18 @@ class ZvukMusicProvider(MusicProvider):
         Called by MA when ``ProviderFeature.TRACK_METADATA`` is declared.
         Returns LRC-synced lyrics (``lrc_lyrics``) when the API returns type
         ``'subtitle'``, otherwise plain text (``lyrics``). Returns ``None`` if
-        the track has no lyrics or the API call fails.
+        the track has no lyrics. Any API errors are caught and return ``None``
+        so that optional metadata enrichment never fails the broader media load.
 
         :param track: The MA Track object. ``item_id`` is used to call the API.
         :return: MediaItemMetadata with lyrics, or None.
         """
         track_id = track.item_id
-        result = await self.client.get_lyrics(track_id)
+        try:
+            result = await self.client.get_lyrics(track_id)
+        except Exception as err:
+            self.logger.debug("Failed to fetch lyrics for track %s: %s", track_id, err)
+            return None
         if not result:
             return None
 

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 from unittest.mock import Mock
 
 import pytest
@@ -54,12 +55,14 @@ def _create_mock_artist(
     if description is not None:
         artist.description = description
     else:
-        del artist.description
+        with contextlib.suppress(AttributeError):
+            del artist.description
 
     if second_image is not None:
         artist.second_image = second_image
     else:
-        del artist.second_image
+        with contextlib.suppress(AttributeError):
+            del artist.second_image
 
     return artist
 
@@ -115,13 +118,15 @@ def _create_mock_release(
         release.genres = genres
     else:
         # SimpleRelease doesn't have genres
-        del release.genres
+        with contextlib.suppress(AttributeError):
+            del release.genres
 
     # Label (only on full Release)
     if label is not None:
         release.label = label
     else:
-        del release.label
+        with contextlib.suppress(AttributeError):
+            del release.label
 
     return release
 
@@ -162,19 +167,22 @@ def _create_mock_track(
     if position is not None:
         track.position = position
     else:
-        del track.position
+        with contextlib.suppress(AttributeError):
+            del track.position
 
     # Genres are only on full Track, not SimpleTrack
     if genres is not None:
         track.genres = genres
     else:
-        del track.genres
+        with contextlib.suppress(AttributeError):
+            del track.genres
 
     # Credits are only on full Track, not SimpleTrack
     if credits_str is not None:
         track.credits = credits_str
     else:
-        del track.credits
+        with contextlib.suppress(AttributeError):
+            del track.credits
 
     return track
 
@@ -205,7 +213,8 @@ def _create_mock_playlist(
     if user_id is not None:
         playlist.user_id = user_id
     else:
-        del playlist.user_id
+        with contextlib.suppress(AttributeError):
+            del playlist.user_id
 
     return playlist
 


### PR DESCRIPTION
Fixes from upstream PR https://github.com/music-assistant/server/pull/3242 Copilot review:

- **constants.py**: `SYNTHESIS_PLAYLIST_IDS` `list[int]` → `tuple[int, ...]` (immutable `Final`)
- **parsers.py**: defensive `getattr(playlist_obj.image, 'src', '')` to avoid AttributeError when `src` missing
- **api_client.py**: defensive loop in `get_editorial_playlist_ids()` with `item.get('id')` and `try/except (TypeError, ValueError)` around `int()`
- **provider.py**: wrap `client.get_lyrics()` in `try/except` — optional metadata enrichment should never propagate errors
- **tests/test_parsers.py**: wrap all `del mock.attr` with `contextlib.suppress(AttributeError)`

N+1 comment on `get_similar_tracks` deferred to future iteration.