### PR TITLE
fix(parsers): use isinstance check for playlist image src

### DIFF
--- a/provider/parsers.py
+++ b/provider/parsers.py
@@ -331,7 +331,8 @@ def parse_playlist(
             # Static avatar images (/static/avatar/...) require Zvuk auth cookies and
             # cannot be fetched publicly; set remotely_accessible=False so MA calls
             # resolve_image() on the provider instead of trying to proxy the URL directly.
-            remotely_accessible = "/static/" not in (getattr(playlist_obj.image, "src", "") or "")
+            src = getattr(playlist_obj.image, "src", None)
+            remotely_accessible = isinstance(src, str) and "/static/" not in src
             playlist.metadata.images = UniqueList(
                 [
                     MediaItemImage(


### PR DESCRIPTION
## Problem

`getattr(playlist_obj.image, 'src', '')` always returns a `Mock` (not the default `''`) because Mock creates attributes dynamically. This caused `'/static/' not in Mock` to raise `TypeError: argument of type 'Mock' is not iterable` in CI.

## Fix

Use `isinstance(src, str)` guard before the `in` check:

```python
src = getattr(playlist_obj.image, 'src', None)
remotely_accessible = isinstance(src, str) and '/static/' not in src
```

Fixes: `tests/providers/zvuk_music/test_parsers.py::TestParsePlaylist::test_parse_playlist_with_image`