### PR TITLE
fix(security,api_client): decouple _request, validate resolve_image domain

### DIFF
--- a/provider/api_client.py
+++ b/provider/api_client.py
@@ -6,6 +6,7 @@ import logging
 from collections.abc import Awaitable, Callable, Sequence
 from typing import Any, ParamSpec, TypeVar, cast
 
+import aiohttp
 from music_assistant_models.errors import (
     LoginFailed,
     ProviderUnavailableError,
@@ -117,6 +118,30 @@ class ZvukMusicClient:
         """Disconnect the client."""
         self._client = None
         self._user_id = None
+
+    async def _tiny_get(self, path: str, params: dict[str, str]) -> dict[str, Any] | None:
+        """Perform an authenticated GET to a /api/tiny endpoint.
+
+        Uses an independent aiohttp session instead of the library's internal
+        _request attribute, avoiding coupling to library implementation details.
+
+        :param path: Endpoint path relative to TINY_API_URL (e.g. ``"lyrics"``).
+        :param params: Query parameters.
+        :return: Parsed JSON dict, or None on non-200 response or empty body.
+        """
+        url = f"{TINY_API_URL}/{path}"
+        headers = {"X-Auth-Token": self._token}
+        try:
+            async with (
+                aiohttp.ClientSession(headers=headers) as session,
+                session.get(url, params=params) as resp,
+            ):
+                if resp.status != 200:
+                    return None
+                return cast("dict[str, Any]", await resp.json())
+        except Exception as err:
+            LOGGER.debug("Tiny API request to %s failed: %s", url, err)
+            return None
 
     def _ensure_connected(self) -> ClientAsync:
         """Ensure the client is connected and return it."""
@@ -313,11 +338,7 @@ class ZvukMusicClient:
         :param quality: Quality string — "flac", "high", or "mid".
         :return: Stream URL string, or None if not found.
         """
-        client = self._ensure_connected()
-        result = await client._request.get(
-            f"{TINY_API_URL}/track/stream",
-            params={"quality": quality, "id": track_id},
-        )
+        result = await self._tiny_get("track/stream", {"quality": quality, "id": track_id})
         if not result or "stream" not in result:
             return None
         return str(result["stream"])
@@ -374,10 +395,8 @@ class ZvukMusicClient:
 
         :return: List of playlist IDs.
         """
-        client = self._ensure_connected()
-        result = await client._request.get(
-            f"{TINY_API_URL}/grid/content",
-            params={"name": "editorial_playlist", "ranker_enabled": "true"},
+        result = await self._tiny_get(
+            "grid/content", {"name": "editorial_playlist", "ranker_enabled": "true"}
         )
         if not result:
             return []
@@ -408,11 +427,7 @@ class ZvukMusicClient:
         :return: Dict with ``lyrics`` (str or None), ``type`` (str or None),
             ``translation`` (str or None), or None on error.
         """
-        client = self._ensure_connected()
-        result = await client._request.get(
-            f"{TINY_API_URL}/lyrics",
-            params={"track_id": track_id},
-        )
+        result = await self._tiny_get("lyrics", {"track_id": track_id})
         if not result or not result.get("lyrics"):
             return None
         return result

--- a/provider/provider.py
+++ b/provider/provider.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from urllib.parse import urlparse
 
 from music_assistant_models.enums import ContentType, MediaType, StreamType
 from music_assistant_models.errors import (
@@ -322,6 +323,8 @@ class ZvukMusicProvider(MusicProvider):
         for related_release in release.related:
             if len(result) >= limit:
                 break
+            if not getattr(related_release, "id", None):
+                continue
             related_full = await self.client.get_release(str(related_release.id))
             if not related_full or not related_full.tracks:
                 continue
@@ -507,9 +510,17 @@ class ZvukMusicProvider(MusicProvider):
         Static playlist avatar images (``/static/avatar/playlist/...``) require
         Zvuk auth cookies and cannot be fetched anonymously.
 
+        Only sends the auth token to trusted Zvuk domains (``zvuk.com``,
+        ``cdn.zvuk.com``) to prevent token leakage to arbitrary hosts.
+
         :param path: Full image URL (e.g. ``https://zvuk.com/static/avatar/...``).
         :return: Raw image bytes on success, original URL string as fallback.
         """
+        _zvuk_image_hosts = frozenset({"zvuk.com", "cdn.zvuk.com"})
+        parsed = urlparse(path)
+        if parsed.hostname not in _zvuk_image_hosts:
+            self.logger.warning("Refusing to fetch image from untrusted host: %s", parsed.hostname)
+            return str(path)
         token = self.config.get_value(CONF_TOKEN)
         try:
             async with self.mass.http_session.get(


### PR DESCRIPTION
Fixes round-2 Copilot review comments on upstream PR [music-assistant/server#3242](https://github.com/music-assistant/server/pull/3242).

## Changes

### 🔒 Security: URL domain validation in `resolve_image`
Before sending `X-Auth-Token`, validate the image URL hostname is `zvuk.com` or `cdn.zvuk.com`. Prevents token leakage to arbitrary domains if image URLs are attacker-controlled.

### 🔧 Decouple from `_request` internal attribute
Added `_tiny_get(path, params)` method to `ZvukMusicClient` that uses an independent `aiohttp.ClientSession` with the auth token. Replaced all 3 usages of `client._request.get()` in:
- `get_direct_stream_url()` — `/api/tiny/track/stream`
- `get_editorial_playlist_ids()` — `/api/tiny/grid/content`
- `get_lyrics()` — `/api/tiny/lyrics`

### 🛡️ Defensive: guard `related_release.id` in `get_similar_tracks`
Added `if not getattr(related_release, 'id', None): continue` before calling `str(related_release.id)`.