### PR TITLE
fix(api_client): use shared http_session instead of per-call aiohttp.ClientSession

### DIFF
--- a/provider/api_client.py
+++ b/provider/api_client.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Awaitable, Callable, Sequence
-from typing import Any, ParamSpec, TypeVar, cast
+from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar, cast
 
-import aiohttp
+if TYPE_CHECKING:
+    import aiohttp
 from music_assistant_models.errors import (
     LoginFailed,
     ProviderUnavailableError,
@@ -78,12 +79,14 @@ def handle_zvuk_errors(
 class ZvukMusicClient:
     """Wrapper around zvuk-music ClientAsync."""
 
-    def __init__(self, token: str) -> None:
+    def __init__(self, token: str, http_session: aiohttp.ClientSession) -> None:
         """Initialize the Zvuk Music client.
 
         :param token: Zvuk Music X-Auth-Token.
+        :param http_session: Shared aiohttp session from MA (``self.mass.http_session``).
         """
         self._token = token
+        self._http_session = http_session
         self._client: ClientAsync | None = None
         self._user_id: str | None = None
 
@@ -122,20 +125,18 @@ class ZvukMusicClient:
     async def _tiny_get(self, path: str, params: dict[str, str]) -> dict[str, Any] | None:
         """Perform an authenticated GET to a /api/tiny endpoint.
 
-        Uses an independent aiohttp session instead of the library's internal
-        _request attribute, avoiding coupling to library implementation details.
+        Reuses the shared ``http_session`` passed at construction to benefit from
+        connection pooling and avoid per-call session overhead.
 
         :param path: Endpoint path relative to TINY_API_URL (e.g. ``"lyrics"``).
         :param params: Query parameters.
         :return: Parsed JSON dict, or None on non-200 response or empty body.
         """
         url = f"{TINY_API_URL}/{path}"
-        headers = {"X-Auth-Token": self._token}
         try:
-            async with (
-                aiohttp.ClientSession(headers=headers) as session,
-                session.get(url, params=params) as resp,
-            ):
+            async with self._http_session.get(
+                url, params=params, headers={"X-Auth-Token": self._token}
+            ) as resp:
                 if resp.status != 200:
                     return None
                 return cast("dict[str, Any]", await resp.json())

--- a/provider/provider.py
+++ b/provider/provider.py
@@ -62,7 +62,7 @@ class ZvukMusicProvider(MusicProvider):
         if not token:
             raise LoginFailed("No Zvuk Music token provided")
 
-        self._client = ZvukMusicClient(str(token))
+        self._client = ZvukMusicClient(str(token), self.mass.http_session)
         await self._client.connect()
         self.logger.info("Successfully connected to Zvuk Music")
 

--- a/tests/test_stream_details.py
+++ b/tests/test_stream_details.py
@@ -50,7 +50,7 @@ class TestGetDirectStreamUrl:
     @pytest.mark.asyncio
     async def test_returns_stream_url_for_flac(self) -> None:
         """get_direct_stream_url returns the stream URL string from API response."""
-        client = ZvukMusicClient(token="test")
+        client = ZvukMusicClient(token="test", http_session=MagicMock())
         client._tiny_get = AsyncMock(  # type: ignore[method-assign]
             return_value={"stream": "https://cdn.zvuk.com/track.flac?token=abc"}
         )
@@ -65,7 +65,7 @@ class TestGetDirectStreamUrl:
     @pytest.mark.asyncio
     async def test_returns_none_when_stream_missing(self) -> None:
         """get_direct_stream_url returns None when API result has no stream key."""
-        client = ZvukMusicClient(token="test")
+        client = ZvukMusicClient(token="test", http_session=MagicMock())
         client._tiny_get = AsyncMock(return_value={})  # type: ignore[method-assign]
 
         url = await client.get_direct_stream_url("12345", "flac")
@@ -75,7 +75,7 @@ class TestGetDirectStreamUrl:
     @pytest.mark.asyncio
     async def test_returns_none_when_api_returns_none(self) -> None:
         """get_direct_stream_url returns None when API returns None."""
-        client = ZvukMusicClient(token="test")
+        client = ZvukMusicClient(token="test", http_session=MagicMock())
         client._tiny_get = AsyncMock(return_value=None)  # type: ignore[method-assign]
 
         url = await client.get_direct_stream_url("12345", "high")
@@ -85,7 +85,7 @@ class TestGetDirectStreamUrl:
     @pytest.mark.asyncio
     async def test_passes_quality_param(self) -> None:
         """get_direct_stream_url passes the quality parameter to the API."""
-        client = ZvukMusicClient(token="test")
+        client = ZvukMusicClient(token="test", http_session=MagicMock())
         client._tiny_get = AsyncMock(  # type: ignore[method-assign]
             return_value={"stream": "https://cdn.zvuk.com/track.mp3"}
         )


### PR DESCRIPTION
Fixes comment [2853245288](https://github.com/music-assistant/server/pull/3242#discussion_r2853245288) on upstream PR.

## Changes

### `ZvukMusicClient` now accepts `http_session` in constructor
Previously `_tiny_get()` created a new `aiohttp.ClientSession` for each call — no connection pooling, wasteful. Now reuses the shared MA session:

```python
# Before
async with aiohttp.ClientSession(headers=...) as session:  # new session per call

# After  
async with self._http_session.get(url, params=params, headers={...}) as resp:  # shared session
```

### `provider.py` passes `self.mass.http_session`
Follows MA convention used by other providers (GPodderClient, YandexMusicClient, etc.).

### Tests updated
Pass `MagicMock()` as `http_session` to match new constructor signature. Tests continue to mock `_tiny_get` directly (option 2 from comment [2853245341](https://github.com/music-assistant/server/pull/3242#discussion_r2853245341)).