### PR TITLE
fix: upstream dev lint parity (strings.json config texts, ruff 0.15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- refactor(config): move `ConfigEntry` labels/descriptions and static `ConfigValueOption` titles into `provider/strings.json` (upstream `check_config_entries` compliance); `ConfigValueOption` calls are now value-only.
+- refactor(browse): add `translation_key` to the «Плейлисты для вас» / «Подборки» recommendation and browse folders, with labels authored in `provider/strings.json` (upstream `check_translatable_labels` compliance).
+- style: ruff 0.15 safe autofixes matching the upstream dev lint rules.
+
 ## [1.8.1] - 2026-03-18
 
 - fix: add zvuk-music[async]==0.6.1 to project dependencies for CI (`c2f6137`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - refactor(config): move `ConfigEntry` labels/descriptions and static `ConfigValueOption` titles into `provider/strings.json` (upstream `check_config_entries` compliance); `ConfigValueOption` calls are now value-only.
 - refactor(browse): add `translation_key` to the «Плейлисты для вас» / «Подборки» recommendation and browse folders, with labels authored in `provider/strings.json` (upstream `check_translatable_labels` compliance).
 - style: ruff 0.15 safe autofixes matching the upstream dev lint rules.
+- refactor: reorder class methods in `api_client.py` / `provider.py` — public methods first, private helpers last (pre-commit `check-method-order` compliance; pure moves, AST-verified no code change).
 
 ## [1.8.1] - 2026-03-18
 

--- a/provider/__init__.py
+++ b/provider/__init__.py
@@ -74,9 +74,6 @@ async def get_config_entries(
         ConfigEntry(
             key=CONF_TOKEN,
             type=ConfigEntryType.SECURE_STRING,
-            label="Zvuk Music Token",
-            description="Enter your Zvuk Music X-Auth-Token. "
-            "See the documentation for how to obtain it.",
             required=True,
             hidden=is_authenticated,
             value=cast("str", values.get(CONF_TOKEN)) if values else None,
@@ -84,19 +81,15 @@ async def get_config_entries(
         ConfigEntry(
             key=CONF_ACTION_CLEAR_AUTH,
             type=ConfigEntryType.ACTION,
-            label="Reset authentication",
-            description="Clear the current authentication details.",
             action=CONF_ACTION_CLEAR_AUTH,
             hidden=not is_authenticated,
         ),
         ConfigEntry(
             key=CONF_QUALITY,
             type=ConfigEntryType.STRING,
-            label="Audio quality",
-            description="Select preferred audio quality.",
             options=[
-                ConfigValueOption("High (320 kbps)", QUALITY_HIGH),
-                ConfigValueOption("Lossless (FLAC)", QUALITY_LOSSLESS),
+                ConfigValueOption(QUALITY_HIGH),
+                ConfigValueOption(QUALITY_LOSSLESS),
             ],
             default_value=QUALITY_HIGH,
         ),

--- a/provider/api_client.py
+++ b/provider/api_client.py
@@ -47,7 +47,8 @@ _NOT_FOUND_SENTINEL: Any = object()
 def handle_zvuk_errors(
     not_found_return: Any = _NOT_FOUND_SENTINEL,
 ) -> Callable[[Callable[_P, Awaitable[_R]]], Callable[_P, Awaitable[_R]]]:
-    """Decorate async methods to map Zvuk API exceptions to MA errors.
+    """
+    Decorate async methods to map Zvuk API exceptions to MA errors.
 
     :param not_found_return: Value to return on NotFoundError (e.g. None or []).
         If not provided, NotFoundError is not caught.
@@ -89,7 +90,8 @@ class ZvukMusicClient:
     """Wrapper around zvuk-music ClientAsync."""
 
     def __init__(self, token: str) -> None:
-        """Initialize the Zvuk Music client.
+        """
+        Initialize the Zvuk Music client.
 
         :param token: Zvuk Music X-Auth-Token.
         """
@@ -106,7 +108,8 @@ class ZvukMusicClient:
         return self._user_id
 
     async def connect(self) -> None:
-        """Initialize the client and verify token validity.
+        """
+        Initialize the client and verify token validity.
 
         :raises LoginFailed: If the token is invalid.
         :raises ResourceTemporarilyUnavailable: If there is a network error.
@@ -154,7 +157,8 @@ class ZvukMusicClient:
         search_releases: bool = True,
         search_playlists: bool = True,
     ) -> ZvukSearch | None:
-        """Search for tracks, albums, artists, or playlists.
+        """
+        Search for tracks, albums, artists, or playlists.
 
         :param query: Search query string.
         :param limit: Maximum number of results per type.
@@ -182,7 +186,8 @@ class ZvukMusicClient:
 
     @handle_zvuk_errors(not_found_return=None)
     async def get_track(self, track_id: str) -> ZvukTrack | None:
-        """Get a single track by ID.
+        """
+        Get a single track by ID.
 
         :param track_id: Track ID.
         :return: Track object or None if not found.
@@ -192,7 +197,8 @@ class ZvukMusicClient:
 
     @handle_zvuk_errors(not_found_return=[])
     async def get_tracks(self, track_ids: list[str]) -> list[ZvukTrack]:
-        """Get multiple tracks by IDs.
+        """
+        Get multiple tracks by IDs.
 
         :param track_ids: List of track IDs.
         :return: List of track objects.
@@ -202,7 +208,8 @@ class ZvukMusicClient:
 
     @handle_zvuk_errors(not_found_return=None)
     async def get_release(self, release_id: str) -> ZvukRelease | None:
-        """Get a single release (album) by ID.
+        """
+        Get a single release (album) by ID.
 
         :param release_id: Release ID.
         :return: Release object or None if not found.
@@ -212,7 +219,8 @@ class ZvukMusicClient:
 
     @handle_zvuk_errors(not_found_return=[])
     async def get_releases(self, release_ids: list[str]) -> list[ZvukRelease]:
-        """Get multiple releases by IDs.
+        """
+        Get multiple releases by IDs.
 
         :param release_ids: List of release IDs.
         :return: List of release objects.
@@ -222,7 +230,8 @@ class ZvukMusicClient:
 
     @handle_zvuk_errors(not_found_return=None)
     async def get_artist(self, artist_id: str) -> ZvukArtist | None:
-        """Get a single artist by ID.
+        """
+        Get a single artist by ID.
 
         :param artist_id: Artist ID.
         :return: Artist object or None if not found.
@@ -232,7 +241,8 @@ class ZvukMusicClient:
 
     @handle_zvuk_errors(not_found_return=[])
     async def get_artists(self, artist_ids: list[str]) -> list[ZvukArtist]:
-        """Get multiple artists by IDs.
+        """
+        Get multiple artists by IDs.
 
         :param artist_ids: List of artist IDs.
         :return: List of artist objects.
@@ -244,7 +254,8 @@ class ZvukMusicClient:
     async def get_artist_releases(
         self, artist_id: str, limit: int = DEFAULT_LIMIT
     ) -> list[ZvukArtist]:
-        """Get artist's releases.
+        """
+        Get artist's releases.
 
         :param artist_id: Artist ID.
         :param limit: Maximum number of releases.
@@ -257,7 +268,8 @@ class ZvukMusicClient:
     async def get_artist_top_tracks(
         self, artist_id: str, limit: int = DEFAULT_LIMIT
     ) -> list[ZvukArtist]:
-        """Get artist's top tracks.
+        """
+        Get artist's top tracks.
 
         :param artist_id: Artist ID.
         :param limit: Maximum number of tracks.
@@ -270,7 +282,8 @@ class ZvukMusicClient:
 
     @handle_zvuk_errors(not_found_return=None)
     async def get_playlist(self, playlist_id: str) -> ZvukPlaylist | None:
-        """Get a playlist by ID.
+        """
+        Get a playlist by ID.
 
         :param playlist_id: Playlist ID.
         :return: Playlist object or None if not found.
@@ -280,7 +293,8 @@ class ZvukMusicClient:
 
     @handle_zvuk_errors(not_found_return=[])
     async def get_playlists(self, playlist_ids: list[str]) -> list[ZvukPlaylist]:
-        """Get multiple playlists by IDs.
+        """
+        Get multiple playlists by IDs.
 
         :param playlist_ids: List of playlist IDs.
         :return: List of playlist objects.
@@ -292,7 +306,8 @@ class ZvukMusicClient:
     async def get_playlist_tracks(
         self, playlist_id: str, limit: int = 50, offset: int = 0
     ) -> list[ZvukSimpleTrack]:
-        """Get playlist tracks.
+        """
+        Get playlist tracks.
 
         :param playlist_id: Playlist ID.
         :param limit: Maximum number of tracks.
@@ -306,7 +321,8 @@ class ZvukMusicClient:
 
     @handle_zvuk_errors(not_found_return=[])
     async def get_stream_urls(self, track_id: str) -> list[ZvukStream]:
-        """Get stream URLs for a track.
+        """
+        Get stream URLs for a track.
 
         :param track_id: Track ID.
         :return: List of Stream objects.
@@ -316,7 +332,8 @@ class ZvukMusicClient:
 
     @handle_zvuk_errors(not_found_return=None)
     async def get_direct_stream_url(self, track_id: str, quality: str) -> str | None:
-        """Get a direct (non-DRM) stream URL for a track.
+        """
+        Get a direct (non-DRM) stream URL for a track.
 
         :param track_id: Track ID.
         :param quality: Quality string — "flac", "high", or "mid".
@@ -334,7 +351,8 @@ class ZvukMusicClient:
 
     @handle_zvuk_errors(not_found_return=None)
     async def get_collection(self) -> Collection | None:
-        """Get user's collection (liked items).
+        """
+        Get user's collection (liked items).
 
         :return: Collection object or None.
         """
@@ -343,7 +361,8 @@ class ZvukMusicClient:
 
     @handle_zvuk_errors(not_found_return=[])
     async def get_liked_tracks(self) -> list[ZvukTrack]:
-        """Get user's liked tracks.
+        """
+        Get user's liked tracks.
 
         :return: List of full Track objects.
         """
@@ -352,7 +371,8 @@ class ZvukMusicClient:
 
     @handle_zvuk_errors(not_found_return=[])
     async def get_user_playlists(self) -> list[ZvukCollectionItem]:
-        """Get user's playlists.
+        """
+        Get user's playlists.
 
         :return: List of CollectionItem objects with playlist IDs.
         """
@@ -363,7 +383,8 @@ class ZvukMusicClient:
     async def get_short_playlists(
         self, playlist_ids: Sequence[int | str]
     ) -> list[ZvukSimplePlaylist]:
-        """Get playlist metadata (title, image, description) by IDs without tracks.
+        """
+        Get playlist metadata (title, image, description) by IDs without tracks.
 
         Uses the lightweight getShortPlaylist GraphQL query which returns only metadata.
         Works for both regular playlists and synthesis playlists (IDs 3,4,6,11,12,13,14,15).
@@ -376,7 +397,8 @@ class ZvukMusicClient:
 
     @handle_zvuk_errors(not_found_return=[])
     async def get_editorial_playlist_ids(self) -> list[str]:
-        """Get editorial (curated) playlist IDs from Zvuk's grid content API.
+        """
+        Get editorial (curated) playlist IDs from Zvuk's grid content API.
 
         Fetches «Подборки» — genre-focused curated playlists shown on the home page.
 
@@ -387,7 +409,8 @@ class ZvukMusicClient:
 
     @handle_zvuk_errors(not_found_return=None)
     async def get_lyrics(self, track_id: str) -> ZvukLyrics | None:
-        """Get lyrics for a track from Zvuk lyrics API.
+        """
+        Get lyrics for a track from Zvuk lyrics API.
 
         Returns synced LRC text (``is_synced=True``) or plain text.
         Returns ``None`` if the track has no lyrics.
@@ -401,7 +424,8 @@ class ZvukMusicClient:
     # Library modifications
 
     async def like_track(self, track_id: str) -> bool:
-        """Add a track to liked tracks.
+        """
+        Add a track to liked tracks.
 
         :param track_id: Track ID.
         :return: True if successful.
@@ -414,7 +438,8 @@ class ZvukMusicClient:
             return False
 
     async def unlike_track(self, track_id: str) -> bool:
-        """Remove a track from liked tracks.
+        """
+        Remove a track from liked tracks.
 
         :param track_id: Track ID.
         :return: True if successful.
@@ -427,7 +452,8 @@ class ZvukMusicClient:
             return False
 
     async def like_release(self, release_id: str) -> bool:
-        """Add a release to liked releases.
+        """
+        Add a release to liked releases.
 
         :param release_id: Release ID.
         :return: True if successful.
@@ -440,7 +466,8 @@ class ZvukMusicClient:
             return False
 
     async def unlike_release(self, release_id: str) -> bool:
-        """Remove a release from liked releases.
+        """
+        Remove a release from liked releases.
 
         :param release_id: Release ID.
         :return: True if successful.
@@ -453,7 +480,8 @@ class ZvukMusicClient:
             return False
 
     async def like_artist(self, artist_id: str) -> bool:
-        """Add an artist to liked artists.
+        """
+        Add an artist to liked artists.
 
         :param artist_id: Artist ID.
         :return: True if successful.
@@ -466,7 +494,8 @@ class ZvukMusicClient:
             return False
 
     async def unlike_artist(self, artist_id: str) -> bool:
-        """Remove an artist from liked artists.
+        """
+        Remove an artist from liked artists.
 
         :param artist_id: Artist ID.
         :return: True if successful.
@@ -479,7 +508,8 @@ class ZvukMusicClient:
             return False
 
     async def like_playlist(self, playlist_id: str) -> bool:
-        """Add a playlist to liked playlists.
+        """
+        Add a playlist to liked playlists.
 
         :param playlist_id: Playlist ID.
         :return: True if successful.
@@ -492,7 +522,8 @@ class ZvukMusicClient:
             return False
 
     async def unlike_playlist(self, playlist_id: str) -> bool:
-        """Remove a playlist from liked playlists.
+        """
+        Remove a playlist from liked playlists.
 
         :param playlist_id: Playlist ID.
         :return: True if successful.
@@ -508,7 +539,8 @@ class ZvukMusicClient:
 
     @handle_zvuk_errors()
     async def create_playlist(self, name: str, track_ids: list[str] | None = None) -> str:
-        """Create a new playlist.
+        """
+        Create a new playlist.
 
         :param name: Playlist name.
         :param track_ids: Optional list of track IDs to add.
@@ -518,7 +550,8 @@ class ZvukMusicClient:
         return await client.create_playlist(name, track_ids=track_ids)
 
     async def delete_playlist(self, playlist_id: str) -> bool:
-        """Delete a playlist.
+        """
+        Delete a playlist.
 
         :param playlist_id: Playlist ID.
         :return: True if successful.
@@ -531,7 +564,8 @@ class ZvukMusicClient:
             return False
 
     async def add_tracks_to_playlist(self, playlist_id: str, track_ids: list[str]) -> bool:
-        """Add tracks to a playlist.
+        """
+        Add tracks to a playlist.
 
         :param playlist_id: Playlist ID.
         :param track_ids: List of track IDs to add.
@@ -545,7 +579,8 @@ class ZvukMusicClient:
             return False
 
     async def update_playlist(self, playlist_id: str, track_ids: list[str]) -> bool:
-        """Update playlist tracks (used for removing tracks by providing remaining ones).
+        """
+        Update playlist tracks (used for removing tracks by providing remaining ones).
 
         :param playlist_id: Playlist ID.
         :param track_ids: Complete list of track IDs the playlist should contain.

--- a/provider/api_client.py
+++ b/provider/api_client.py
@@ -133,19 +133,6 @@ class ZvukMusicClient:
         self._client = None
         self._user_id = None
 
-    def _ensure_connected(self) -> ClientAsync:
-        """Ensure the client is connected and return it."""
-        if self._client is None:
-            raise ProviderUnavailableError("Client not connected, call connect() first")
-        return self._client
-
-    async def _get_client(self) -> ClientAsync:
-        """Acquire a throttle slot then return the connected client."""
-        await self._throttler.acquire()
-        return self._ensure_connected()
-
-    # Search
-
     @handle_zvuk_errors(not_found_return=None)
     async def search(
         self,
@@ -181,8 +168,6 @@ class ZvukMusicClient:
             profiles=False,
             books=False,
         )
-
-    # Get single items
 
     @handle_zvuk_errors(not_found_return=None)
     async def get_track(self, track_id: str) -> ZvukTrack | None:
@@ -278,8 +263,6 @@ class ZvukMusicClient:
         client = await self._get_client()
         return await client.get_artists([artist_id], with_popular_tracks=True, tracks_limit=limit)
 
-    # Playlists
-
     @handle_zvuk_errors(not_found_return=None)
     async def get_playlist(self, playlist_id: str) -> ZvukPlaylist | None:
         """
@@ -317,8 +300,6 @@ class ZvukMusicClient:
         client = await self._get_client()
         return await client.get_playlist_tracks(playlist_id, limit=limit, offset=offset)
 
-    # Streaming
-
     @handle_zvuk_errors(not_found_return=[])
     async def get_stream_urls(self, track_id: str) -> list[ZvukStream]:
         """
@@ -346,8 +327,6 @@ class ZvukMusicClient:
         if not result:
             return None
         return result.stream or None
-
-    # Collection (Library)
 
     @handle_zvuk_errors(not_found_return=None)
     async def get_collection(self) -> Collection | None:
@@ -420,8 +399,6 @@ class ZvukMusicClient:
         """
         client = await self._get_client()
         return await client.get_lyrics(track_id)
-
-    # Library modifications
 
     async def like_track(self, track_id: str) -> bool:
         """
@@ -535,8 +512,6 @@ class ZvukMusicClient:
             LOGGER.error("Error unliking playlist %s: %s", playlist_id, err)
             return False
 
-    # Playlist management
-
     @handle_zvuk_errors()
     async def create_playlist(self, name: str, track_ids: list[str] | None = None) -> str:
         """
@@ -592,3 +567,14 @@ class ZvukMusicClient:
         except (BadRequestError, NetworkError, GraphQLError) as err:
             LOGGER.error("Error updating playlist %s: %s", playlist_id, err)
             return False
+
+    def _ensure_connected(self) -> ClientAsync:
+        """Ensure the client is connected and return it."""
+        if self._client is None:
+            raise ProviderUnavailableError("Client not connected, call connect() first")
+        return self._client
+
+    async def _get_client(self) -> ClientAsync:
+        """Acquire a throttle slot then return the connected client."""
+        await self._throttler.acquire()
+        return self._ensure_connected()

--- a/provider/parsers.py
+++ b/provider/parsers.py
@@ -42,7 +42,8 @@ if TYPE_CHECKING:
 
 
 def _get_image_url(image: ZvukImage | None, size: int = IMAGE_SIZE_LARGE) -> str | None:
-    """Convert Zvuk Image to full URL with guaranteed square dimensions.
+    """
+    Convert Zvuk Image to full URL with guaranteed square dimensions.
 
     :param image: Zvuk Image object.
     :param size: Image size in pixels (applied as both width and height).
@@ -70,7 +71,8 @@ def _get_image_url(image: ZvukImage | None, size: int = IMAGE_SIZE_LARGE) -> str
 
 
 def parse_artist(provider: ZvukMusicProvider, artist_obj: ZvukArtist | ZvukSimpleArtist) -> Artist:
-    """Parse Zvuk artist object to MA Artist model.
+    """
+    Parse Zvuk artist object to MA Artist model.
 
     :param provider: The Zvuk Music provider instance.
     :param artist_obj: Zvuk artist or SimpleArtist object.
@@ -128,7 +130,8 @@ def parse_artist(provider: ZvukMusicProvider, artist_obj: ZvukArtist | ZvukSimpl
 
 
 def parse_album(provider: ZvukMusicProvider, release_obj: ZvukRelease | ZvukSimpleRelease) -> Album:
-    """Parse Zvuk release object to MA Album model.
+    """
+    Parse Zvuk release object to MA Album model.
 
     :param provider: The Zvuk Music provider instance.
     :param release_obj: Zvuk release or SimpleRelease object.
@@ -218,7 +221,8 @@ def parse_album(provider: ZvukMusicProvider, release_obj: ZvukRelease | ZvukSimp
 
 
 def parse_track(provider: ZvukMusicProvider, track_obj: ZvukTrack | ZvukSimpleTrack) -> Track:
-    """Parse Zvuk track object to MA Track model.
+    """
+    Parse Zvuk track object to MA Track model.
 
     :param provider: The Zvuk Music provider instance.
     :param track_obj: Zvuk track or SimpleTrack object.
@@ -301,7 +305,8 @@ def parse_track(provider: ZvukMusicProvider, track_obj: ZvukTrack | ZvukSimpleTr
 def parse_playlist(
     provider: ZvukMusicProvider, playlist_obj: ZvukPlaylist | ZvukSimplePlaylist
 ) -> Playlist:
-    """Parse Zvuk playlist object to MA Playlist model.
+    """
+    Parse Zvuk playlist object to MA Playlist model.
 
     :param provider: The Zvuk Music provider instance.
     :param playlist_obj: Zvuk playlist or SimplePlaylist object.

--- a/provider/provider.py
+++ b/provider/provider.py
@@ -71,7 +71,8 @@ class ZvukMusicProvider(MusicProvider):
         self.logger.info("Successfully connected to Zvuk Music")
 
     async def unload(self, is_removed: bool = False) -> None:
-        """Handle unload/close of the provider.
+        """
+        Handle unload/close of the provider.
 
         :param is_removed: Whether the provider is being removed.
         """
@@ -81,7 +82,8 @@ class ZvukMusicProvider(MusicProvider):
         await super().unload(is_removed)
 
     def get_item_mapping(self, media_type: MediaType | str, key: str, name: str) -> ItemMapping:
-        """Create a generic item mapping.
+        """
+        Create a generic item mapping.
 
         :param media_type: The media type.
         :param key: The item ID.
@@ -103,7 +105,8 @@ class ZvukMusicProvider(MusicProvider):
     async def search(
         self, search_query: str, media_types: list[MediaType], limit: int = 5
     ) -> SearchResults:
-        """Perform search on Zvuk Music.
+        """
+        Perform search on Zvuk Music.
 
         :param search_query: The search query.
         :param media_types: List of media types to search for.
@@ -161,7 +164,8 @@ class ZvukMusicProvider(MusicProvider):
 
     @use_cache(3600 * 24 * 30)
     async def get_artist(self, prov_artist_id: str) -> Artist:
-        """Get artist details by ID.
+        """
+        Get artist details by ID.
 
         :param prov_artist_id: The provider artist ID.
         :return: Artist object.
@@ -174,7 +178,8 @@ class ZvukMusicProvider(MusicProvider):
 
     @use_cache(3600 * 24 * 30)
     async def get_album(self, prov_album_id: str) -> Album:
-        """Get album details by ID.
+        """
+        Get album details by ID.
 
         :param prov_album_id: The provider album ID.
         :return: Album object.
@@ -187,7 +192,8 @@ class ZvukMusicProvider(MusicProvider):
 
     @use_cache(3600 * 24 * 30)
     async def get_track(self, prov_track_id: str) -> Track:
-        """Get track details by ID.
+        """
+        Get track details by ID.
 
         :param prov_track_id: The provider track ID.
         :return: Track object.
@@ -200,7 +206,8 @@ class ZvukMusicProvider(MusicProvider):
 
     @use_cache(3600 * 24 * 30)
     async def get_playlist(self, prov_playlist_id: str) -> Playlist:
-        """Get playlist details by ID.
+        """
+        Get playlist details by ID.
 
         :param prov_playlist_id: The provider playlist ID.
         :return: Playlist object.
@@ -215,7 +222,8 @@ class ZvukMusicProvider(MusicProvider):
 
     @use_cache(3600 * 24 * 30)
     async def get_album_tracks(self, prov_album_id: str) -> list[Track]:
-        """Get album tracks.
+        """
+        Get album tracks.
 
         :param prov_album_id: The provider album ID.
         :return: List of Track objects.
@@ -237,7 +245,8 @@ class ZvukMusicProvider(MusicProvider):
 
     @use_cache(3600 * 3)
     async def get_playlist_tracks(self, prov_playlist_id: str, page: int = 0) -> list[Track]:
-        """Get playlist tracks.
+        """
+        Get playlist tracks.
 
         :param prov_playlist_id: The provider playlist ID.
         :param page: Page number for pagination.
@@ -266,7 +275,8 @@ class ZvukMusicProvider(MusicProvider):
 
     @use_cache(3600 * 24 * 7)
     async def get_artist_albums(self, prov_artist_id: str) -> list[Album]:
-        """Get artist's albums.
+        """
+        Get artist's albums.
 
         :param prov_artist_id: The provider artist ID.
         :return: List of Album objects.
@@ -286,7 +296,8 @@ class ZvukMusicProvider(MusicProvider):
 
     @use_cache(3600 * 24 * 7)
     async def get_artist_toptracks(self, prov_artist_id: str) -> list[Track]:
-        """Get artist's top tracks.
+        """
+        Get artist's top tracks.
 
         :param prov_artist_id: The provider artist ID.
         :return: List of Track objects.
@@ -306,7 +317,8 @@ class ZvukMusicProvider(MusicProvider):
 
     @use_cache(3600 * 24 * 7)
     async def get_similar_tracks(self, prov_track_id: str, limit: int = 25) -> list[Track]:
-        """Get similar tracks based on related releases of the track's album.
+        """
+        Get similar tracks based on related releases of the track's album.
 
         Uses the Zvuk ``release.related`` field to find similar releases and samples tracks from
         them. Only called if provider supports ProviderFeature.SIMILAR_TRACKS.
@@ -351,7 +363,8 @@ class ZvukMusicProvider(MusicProvider):
         parser: Any,
         item_type: str,
     ) -> AsyncGenerator[Any]:
-        """Yield parsed items by fetching ``ids`` in batches of DEFAULT_LIMIT.
+        """
+        Yield parsed items by fetching ``ids`` in batches of DEFAULT_LIMIT.
 
         :param ids: List of item IDs to fetch.
         :param fetcher: Async callable that accepts a list of IDs and returns a list of raw items.
@@ -397,7 +410,8 @@ class ZvukMusicProvider(MusicProvider):
             yield track
 
     async def get_library_playlists(self) -> AsyncGenerator[Playlist]:
-        """Retrieve library playlists from Zvuk Music.
+        """
+        Retrieve library playlists from Zvuk Music.
 
         Yields user's own playlists followed by Zvuk's personalized synthesis
         playlists («Плейлисты для вас»: IDs 3, 4, 6, 11, 12, 13, 14, 15).
@@ -444,7 +458,8 @@ class ZvukMusicProvider(MusicProvider):
         return result
 
     async def recommendations(self) -> list[RecommendationFolder]:
-        """Return personalized and editorial playlist recommendations.
+        """
+        Return personalized and editorial playlist recommendations.
 
         Returns two folders:
         - «Плейлисты для вас»: Zvuk's AI-generated personalized playlists.
@@ -460,6 +475,7 @@ class ZvukMusicProvider(MusicProvider):
                     item_id="for_you",
                     provider=self.instance_id,
                     name="Плейлисты для вас",
+                    translation_key="for_you",
                     subtitle="Персональные плейлисты от Звук",
                     icon="mdi-playlist-music",
                     items=for_you_items,  # type: ignore[arg-type]
@@ -474,6 +490,7 @@ class ZvukMusicProvider(MusicProvider):
                     item_id="editorial",
                     provider=self.instance_id,
                     name="Подборки",
+                    translation_key="editorial",
                     subtitle="Плейлисты от редакции Звук по жанрам",
                     icon="mdi-music-box-multiple",
                     items=editorial_items,  # type: ignore[arg-type]
@@ -483,7 +500,8 @@ class ZvukMusicProvider(MusicProvider):
         return folders
 
     async def browse(self, path: str) -> list[MediaItemType | ItemMapping | BrowseFolder]:
-        """Browse provider content as a hierarchical folder tree.
+        """
+        Browse provider content as a hierarchical folder tree.
 
         Root level exposes two folders:
         - «Плейлисты для вас»: Zvuk AI-generated personalized playlists.
@@ -518,17 +536,20 @@ class ZvukMusicProvider(MusicProvider):
                 provider=self.instance_id,
                 path=f"{base}for_you",
                 name="Плейлисты для вас",
+                translation_key="for_you",
             ),
             BrowseFolder(
                 item_id="editorial",
                 provider=self.instance_id,
                 path=f"{base}editorial",
                 name="Подборки",
+                translation_key="editorial",
             ),
         ]
 
     async def get_track_metadata(self, track: Track) -> MediaItemMetadata | None:
-        """Fetch lyrics for a track from Zvuk's lyrics API.
+        """
+        Fetch lyrics for a track from Zvuk's lyrics API.
 
         Called by MA when ``ProviderFeature.TRACK_METADATA`` is declared.
         Returns LRC-synced lyrics (``lrc_lyrics``) when the API returns type
@@ -561,7 +582,8 @@ class ZvukMusicProvider(MusicProvider):
         return metadata
 
     async def resolve_image(self, path: str) -> str | bytes:
-        """Fetch a Zvuk image with optional authentication.
+        """
+        Fetch a Zvuk image with optional authentication.
 
         Called by MA when a ``MediaItemImage`` has ``remotely_accessible=False``.
         Static playlist avatar images (``/static/avatar/playlist/...``) require
@@ -608,7 +630,8 @@ class ZvukMusicProvider(MusicProvider):
     # Library edit methods
 
     async def library_add(self, item: MediaItemType) -> bool:
-        """Add item to library.
+        """
+        Add item to library.
 
         :param item: The media item to add.
         :return: True if successful.
@@ -628,7 +651,8 @@ class ZvukMusicProvider(MusicProvider):
         return False
 
     async def library_remove(self, prov_item_id: str, media_type: MediaType) -> bool:
-        """Remove item from library.
+        """
+        Remove item from library.
 
         :param prov_item_id: The provider item ID.
         :param media_type: The media type.
@@ -654,7 +678,8 @@ class ZvukMusicProvider(MusicProvider):
     # Playlist management
 
     async def create_playlist(self, name: str, media_types: set[MediaType]) -> Playlist:
-        """Create a new playlist.
+        """
+        Create a new playlist.
 
         :param name: Playlist name.
         :param media_types: Ignored — Zvuk playlists are always track-based.
@@ -667,7 +692,8 @@ class ZvukMusicProvider(MusicProvider):
         return parse_playlist(self, playlist)
 
     async def add_playlist_tracks(self, prov_playlist_id: str, prov_track_ids: list[str]) -> None:
-        """Add tracks to a playlist.
+        """
+        Add tracks to a playlist.
 
         :param prov_playlist_id: The provider playlist ID.
         :param prov_track_ids: List of track IDs to add.
@@ -677,7 +703,8 @@ class ZvukMusicProvider(MusicProvider):
     async def remove_playlist_tracks(
         self, prov_playlist_id: str, positions_to_remove: tuple[int, ...]
     ) -> None:
-        """Remove tracks from a playlist by position.
+        """
+        Remove tracks from a playlist by position.
 
         :param prov_playlist_id: The provider playlist ID.
         :param positions_to_remove: Tuple of track positions (0-based) to remove.
@@ -697,7 +724,8 @@ class ZvukMusicProvider(MusicProvider):
     async def get_stream_details(
         self, item_id: str, media_type: MediaType = MediaType.TRACK
     ) -> StreamDetails:
-        """Get stream details for a track.
+        """
+        Get stream details for a track.
 
         Uses /api/tiny/track/stream to get a direct (non-DRM) URL. When lossless is
         requested, always tries "flac" quality first, then falls back through "high"

--- a/provider/provider.py
+++ b/provider/provider.py
@@ -99,8 +99,6 @@ class ZvukMusicProvider(MusicProvider):
             name=name,
         )
 
-    # Search
-
     @use_cache(3600 * 24 * 14)
     async def search(
         self, search_query: str, media_types: list[MediaType], limit: int = 5
@@ -160,8 +158,6 @@ class ZvukMusicProvider(MusicProvider):
 
         return result
 
-    # Get single items
-
     @use_cache(3600 * 24 * 30)
     async def get_artist(self, prov_artist_id: str) -> Artist:
         """
@@ -217,8 +213,6 @@ class ZvukMusicProvider(MusicProvider):
         if not playlist:
             raise MediaNotFoundError(f"Playlist {prov_playlist_id} not found")
         return parse_playlist(self, playlist)
-
-    # Get related items
 
     @use_cache(3600 * 24 * 30)
     async def get_album_tracks(self, prov_album_id: str) -> list[Track]:
@@ -354,32 +348,6 @@ class ZvukMusicProvider(MusicProvider):
 
         return result[:limit]
 
-    # Library methods
-
-    async def _iter_batched(
-        self,
-        ids: list[str],
-        fetcher: Any,
-        parser: Any,
-        item_type: str,
-    ) -> AsyncGenerator[Any]:
-        """
-        Yield parsed items by fetching ``ids`` in batches of DEFAULT_LIMIT.
-
-        :param ids: List of item IDs to fetch.
-        :param fetcher: Async callable that accepts a list of IDs and returns a list of raw items.
-        :param parser: Callable(provider, raw_item) → MA media item.
-        :param item_type: Human-readable type name for debug log messages.
-        """
-        for i in range(0, len(ids), DEFAULT_LIMIT):
-            batch = ids[i : i + DEFAULT_LIMIT]
-            items = await fetcher(batch)
-            for item in items:
-                try:
-                    yield parser(self, item)
-                except InvalidDataError as err:
-                    self.logger.debug("Error parsing library %s: %s", item_type, err)
-
     async def get_library_artists(self) -> AsyncGenerator[Artist]:
         """Retrieve library artists from Zvuk Music."""
         collection = await self.client.get_collection()
@@ -431,31 +399,6 @@ class ZvukMusicProvider(MusicProvider):
                 yield parse_playlist(self, simple_pl)
             except InvalidDataError as err:
                 self.logger.debug("Error parsing synthesis playlist: %s", err)
-
-    async def _get_for_you_playlists(self) -> list[Playlist]:
-        """Fetch and parse Zvuk's personalized synthesis playlists («Плейлисты для вас»)."""
-        synthesis_playlists = await self.client.get_short_playlists(SYNTHESIS_PLAYLIST_IDS)
-        result: list[Playlist] = []
-        for simple_pl in synthesis_playlists:
-            try:
-                result.append(parse_playlist(self, simple_pl))
-            except InvalidDataError as err:
-                self.logger.debug("Error parsing synthesis playlist: %s", err)
-        return result
-
-    async def _get_editorial_playlists(self) -> list[Playlist]:
-        """Fetch and parse Zvuk's editorial curated playlists («Подборки»)."""
-        editorial_ids = await self.client.get_editorial_playlist_ids()
-        if not editorial_ids:
-            return []
-        full_playlists = await self.client.get_playlists(editorial_ids[:DEFAULT_LIMIT])
-        result: list[Playlist] = []
-        for full_pl in full_playlists:
-            try:
-                result.append(parse_playlist(self, full_pl))
-            except InvalidDataError as err:
-                self.logger.debug("Error parsing editorial playlist: %s", err)
-        return result
 
     async def recommendations(self) -> list[RecommendationFolder]:
         """
@@ -627,8 +570,6 @@ class ZvukMusicProvider(MusicProvider):
             self.logger.debug("Failed to resolve image %s: %s", path, err)
         return str(path)
 
-    # Library edit methods
-
     async def library_add(self, item: MediaItemType) -> bool:
         """
         Add item to library.
@@ -667,15 +608,6 @@ class ZvukMusicProvider(MusicProvider):
         if media_type == MediaType.PLAYLIST:
             return await self.client.unlike_playlist(prov_item_id)
         return False
-
-    def _get_provider_item_id(self, item: MediaItemType) -> str | None:
-        """Get provider item ID from media item."""
-        for mapping in item.provider_mappings:
-            if mapping.provider_instance == self.instance_id:
-                return mapping.item_id
-        return item.item_id if item.provider == self.instance_id else None
-
-    # Playlist management
 
     async def create_playlist(self, name: str, media_types: set[MediaType]) -> Playlist:
         """
@@ -718,8 +650,6 @@ class ZvukMusicProvider(MusicProvider):
             str(t.id) for i, t in enumerate(simple_tracks) if t.id and i not in remove_positions
         ]
         await self.client.update_playlist(prov_playlist_id, remaining_ids)
-
-    # Streaming
 
     async def get_stream_details(
         self, item_id: str, media_type: MediaType = MediaType.TRACK
@@ -812,3 +742,59 @@ class ZvukMusicProvider(MusicProvider):
             allow_seek=True,
             can_seek=True,
         )
+
+    async def _iter_batched(
+        self,
+        ids: list[str],
+        fetcher: Any,
+        parser: Any,
+        item_type: str,
+    ) -> AsyncGenerator[Any]:
+        """
+        Yield parsed items by fetching ``ids`` in batches of DEFAULT_LIMIT.
+
+        :param ids: List of item IDs to fetch.
+        :param fetcher: Async callable that accepts a list of IDs and returns a list of raw items.
+        :param parser: Callable(provider, raw_item) → MA media item.
+        :param item_type: Human-readable type name for debug log messages.
+        """
+        for i in range(0, len(ids), DEFAULT_LIMIT):
+            batch = ids[i : i + DEFAULT_LIMIT]
+            items = await fetcher(batch)
+            for item in items:
+                try:
+                    yield parser(self, item)
+                except InvalidDataError as err:
+                    self.logger.debug("Error parsing library %s: %s", item_type, err)
+
+    async def _get_for_you_playlists(self) -> list[Playlist]:
+        """Fetch and parse Zvuk's personalized synthesis playlists («Плейлисты для вас»)."""
+        synthesis_playlists = await self.client.get_short_playlists(SYNTHESIS_PLAYLIST_IDS)
+        result: list[Playlist] = []
+        for simple_pl in synthesis_playlists:
+            try:
+                result.append(parse_playlist(self, simple_pl))
+            except InvalidDataError as err:
+                self.logger.debug("Error parsing synthesis playlist: %s", err)
+        return result
+
+    async def _get_editorial_playlists(self) -> list[Playlist]:
+        """Fetch and parse Zvuk's editorial curated playlists («Подборки»)."""
+        editorial_ids = await self.client.get_editorial_playlist_ids()
+        if not editorial_ids:
+            return []
+        full_playlists = await self.client.get_playlists(editorial_ids[:DEFAULT_LIMIT])
+        result: list[Playlist] = []
+        for full_pl in full_playlists:
+            try:
+                result.append(parse_playlist(self, full_pl))
+            except InvalidDataError as err:
+                self.logger.debug("Error parsing editorial playlist: %s", err)
+        return result
+
+    def _get_provider_item_id(self, item: MediaItemType) -> str | None:
+        """Get provider item ID from media item."""
+        for mapping in item.provider_mappings:
+            if mapping.provider_instance == self.instance_id:
+                return mapping.item_id
+        return item.item_id if item.provider == self.instance_id else None

--- a/provider/strings.json
+++ b/provider/strings.json
@@ -1,0 +1,30 @@
+{
+  "config_entries": {
+    "token": {
+      "label": "Zvuk Music Token",
+      "description": "Enter your Zvuk Music X-Auth-Token. See the documentation for how to obtain it."
+    },
+    "clear_auth": {
+      "label": "Reset authentication",
+      "description": "Clear the current authentication details."
+    },
+    "quality": {
+      "label": "Audio quality",
+      "description": "Select preferred audio quality.",
+      "options": {
+        "high": "High (320 kbps)",
+        "lossless": "Lossless (FLAC)"
+      }
+    }
+  },
+  "media": {
+    "folder": {
+      "for_you": {
+        "name": "Плейлисты для вас"
+      },
+      "editorial": {
+        "name": "Подборки"
+      }
+    }
+  }
+}

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -35,7 +35,8 @@ def _make_client(token: str = "test-token") -> ZvukMusicClient:  # noqa: S107
 
 
 def _make_connected_client() -> tuple[ZvukMusicClient, MagicMock]:
-    """Create a ZvukMusicClient with _client already set (simulates post-connect state).
+    """
+    Create a ZvukMusicClient with _client already set (simulates post-connect state).
 
     :return: Tuple of (client, inner_mock) where inner_mock is the mocked ClientAsync.
     """

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -18,7 +18,8 @@ from music_assistant.providers.zvuk_music.parsers import (
 
 
 def _create_mock_image(template: str = "https://zvuk.com/image/{width}x{height}") -> Mock:
-    """Create a mock Zvuk Image object.
+    """
+    Create a mock Zvuk Image object.
 
     :param template: URL template with {width} and {height} placeholders.
     :return: Mock Image object.
@@ -37,7 +38,8 @@ def _create_mock_artist(
     description: str | None = None,
     second_image: Mock | None = None,
 ) -> Mock:
-    """Create a mock Zvuk artist object.
+    """
+    Create a mock Zvuk artist object.
 
     :param artist_id: Artist ID.
     :param title: Artist name.
@@ -78,7 +80,8 @@ def _create_mock_release(
     label: Mock | None = None,
     image: Mock | None = None,
 ) -> Mock:
-    """Create a mock Zvuk release object.
+    """
+    Create a mock Zvuk release object.
 
     :param release_id: Release ID.
     :param title: Album title.
@@ -142,7 +145,8 @@ def _create_mock_track(
     genres: list[Mock] | None = None,
     credits_str: str | None = None,
 ) -> Mock:
-    """Create a mock Zvuk track object.
+    """
+    Create a mock Zvuk track object.
 
     :param track_id: Track ID.
     :param title: Track title.
@@ -194,7 +198,8 @@ def _create_mock_playlist(
     user_id: int | None = None,
     image: Mock | None = None,
 ) -> Mock:
-    """Create a mock Zvuk playlist object.
+    """
+    Create a mock Zvuk playlist object.
 
     :param playlist_id: Playlist ID.
     :param title: Playlist title.
@@ -710,7 +715,8 @@ class TestParsePlaylist:
         assert result.name == "Unknown Playlist"
 
     def test_parse_playlist_image_src_none(self, mock_provider: Mock) -> None:
-        """Test parsing a playlist whose Image object has src=None does not raise.
+        """
+        Test parsing a playlist whose Image object has src=None does not raise.
 
         Regression test for AttributeError when image.get_url() is called with src=None.
         Zvuk API returns Image objects with src=None for user-created playlists without covers.
@@ -730,7 +736,8 @@ class TestParsePlaylist:
         assert result.metadata.images is None or len(result.metadata.images) == 0
 
     def test_parse_playlist_simple_playlist_no_user_id(self, mock_provider: Mock) -> None:
-        """Test that SimplePlaylist (no user_id) is parsed as not editable.
+        """
+        Test that SimplePlaylist (no user_id) is parsed as not editable.
 
         Synthesis playlists (IDs 3,4,6,11,12,13,14,15) are returned as SimplePlaylist
         objects by get_short_playlist() — they have no user_id attribute.

--- a/tests/test_stream_details.py
+++ b/tests/test_stream_details.py
@@ -15,7 +15,8 @@ from music_assistant.providers.zvuk_music.provider import ZvukMusicProvider
 
 
 def _make_mock_track(has_flac: bool = True, duration: int = 240) -> MagicMock:
-    """Create a mock ZvukTrack with configurable has_flac and duration.
+    """
+    Create a mock ZvukTrack with configurable has_flac and duration.
 
     :param has_flac: Whether FLAC is available for this track.
     :param duration: Track duration in seconds.
@@ -28,7 +29,8 @@ def _make_mock_track(has_flac: bool = True, duration: int = 240) -> MagicMock:
 
 
 def _make_provider(quality_pref: str) -> ZvukMusicProvider:
-    """Create a ZvukMusicProvider with mocked MA and config.
+    """
+    Create a ZvukMusicProvider with mocked MA and config.
 
     :param quality_pref: Quality preference string ("lossless" or "high").
     :return: Configured provider instance.


### PR DESCRIPTION
## Description

Moves `ConfigEntry` labels/descriptions and static `ConfigValueOption` titles into `provider/strings.json`; `ConfigValueOption` calls are now value-only (also fixes the latent title/value positional swap vs current `music-assistant-models`). Adds `translation_key` to the «Плейлисты для вас» / «Подборки» recommendation and browse folders with labels authored in strings.json.

Also includes the ruff 0.15 **safe** autofixes (D213 docstring style etc.) that provider CI would otherwise auto-commit on the next push once the new dev-mirrored lint config lands.

**Context:** trudenboy/ma-provider-tools#119 switches provider CI to full lint parity with `music-assistant/server` **dev** (dev-synced ruff rules, ruff 0.15, and a new *Upstream repo checks* gate running upstream's `check_*` pre-commit scripts). This PR fixes everything that gate and rule set flag in this repo, so CI stays green after the rollout — these were previously silent failures that would only surface on the first upstream PR.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] CI/Infrastructure
- [x] Refactoring

## Testing

- [ ] Tests pass locally (`uv run pytest`) — not run locally (needs full MA env); PR CI runs the suite
- [x] Lint passes — ruff 0.15 with the upstream-dev config: 0 findings; simulated the new *Upstream repo checks* gate against a fresh `music-assistant/server@dev` clone on Python 3.14: all checks green; `py3.14 -m compileall` clean
- [ ] New/changed code is covered by tests — no behavior change intended (texts move to strings.json)

## Checklist

- [x] Documentation updated if behavior changed (CHANGELOG entry added)
- [x] No secrets or credentials committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)