### PR TITLE
style: auto-fix ruff (repo-pinned pass)

### DIFF
--- a/tests/test_provider_browse.py
+++ b/tests/test_provider_browse.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, Mock
 import pytest
 from music_assistant_models.enums import ProviderFeature
 from music_assistant_models.media_items import BrowseFolder, Playlist, RecommendationFolder
+
 from provider.constants import PLAYLIST_TRACK_FETCH_LIMIT
 from provider.provider import ZvukMusicProvider
 


### PR DESCRIPTION
The gate's autofix pass produces this one-line change, but its bot commit cannot land on the protected `dev` branch (GH006: required check `version-guard` expected) — the 1.8.3 release pipeline dies at *Commit auto-fixes*. Landing it via PR so the autofix step finds nothing to commit.

(Systemic fix for the bot-push-vs-protected-branch conflict follows in ma-provider-tools.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)