### PR TITLE
reverse-sync: Load Discover recommendation rows on demand and improve Recently Played (#4487)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,3 +192,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat: add Zvuk Music provider scaffold (manifest, constants, icons)
 - feat: add Zvuk Music API client and model parsers
 - feat: implement ZvukMusicProvider (browse, search, streaming)
+- Reverse-synced upstream PR #4487 (WIP)

--- a/provider/provider.py
+++ b/provider/provider.py
@@ -26,6 +26,7 @@ from music_assistant_models.media_items import (
     RecommendationFolder,
     SearchResults,
     Track,
+    UniqueList,
 )
 from music_assistant_models.streamdetails import StreamDetails
 
@@ -400,46 +401,74 @@ class ZvukMusicProvider(MusicProvider):
             except InvalidDataError as err:
                 self.logger.debug("Error parsing synthesis playlist: %s", err)
 
+<<<<<<< ours
     async def recommendations(self) -> list[RecommendationFolder]:
+=======
+    async def _get_for_you_playlists(self) -> list[Playlist]:
+        """Fetch and parse Zvuk's personalized synthesis playlists («Плейлисты для вас»)."""
+        synthesis_playlists = await self.client.get_short_playlists(SYNTHESIS_PLAYLIST_IDS)
+        result: list[Playlist] = []
+        for simple_pl in synthesis_playlists:
+            try:
+                result.append(parse_playlist(self, simple_pl))
+            except InvalidDataError as err:
+                self.logger.debug("Error parsing synthesis playlist: %s", err)
+        return result
+
+    async def _get_editorial_playlists(self) -> list[Playlist]:
+        """Fetch and parse Zvuk's editorial curated playlists («Подборки»)."""
+        editorial_ids = await self.client.get_editorial_playlist_ids()
+        if not editorial_ids:
+            return []
+        full_playlists = await self.client.get_playlists(editorial_ids[:DEFAULT_LIMIT])
+        result: list[Playlist] = []
+        for full_pl in full_playlists:
+            try:
+                result.append(parse_playlist(self, full_pl))
+            except InvalidDataError as err:
+                self.logger.debug("Error parsing editorial playlist: %s", err)
+        return result
+
+    async def get_recommendations(self) -> list[RecommendationFolder]:
+>>>>>>> theirs
         """
-        Return personalized and editorial playlist recommendations.
+        Return the available recommendation rows, without items.
 
-        Returns two folders:
-        - "Made for you": Zvuk's AI-generated personalized playlists.
-        - "Collections": Editorial genre-themed curated playlists.
+        Two rows:
+        - "for_you" ("Made for you"): Zvuk's AI-generated personalized playlists.
+        - "editorial" ("Collections"): Editorial genre-themed curated playlists.
         """
-        folders: list[RecommendationFolder] = []
+        return [
+            RecommendationFolder(
+                item_id="for_you",
+                provider=self.instance_id,
+                name="Made for you",
+                translation_key="made_for_you",
+                icon="mdi-playlist-music",
+            ),
+            RecommendationFolder(
+                item_id="editorial",
+                provider=self.instance_id,
+                name="Collections",
+                subtitle="Editorial playlists from Zvuk by genre",
+                translation_key="editorial",
+                icon="mdi-music-box-multiple",
+            ),
+        ]
 
-        # Folder 1: Personalized synthesis playlists ("Made for you")
-        for_you_items = await self._get_for_you_playlists()
-        if for_you_items:
-            folders.append(
-                RecommendationFolder(
-                    item_id="for_you",
-                    provider=self.instance_id,
-                    name="Made for you",
-                    translation_key="made_for_you",
-                    icon="mdi-playlist-music",
-                    items=for_you_items,  # type: ignore[arg-type]
-                )
-            )
+    async def get_recommendation_items(
+        self, item_id: str
+    ) -> UniqueList[MediaItemType | ItemMapping | BrowseFolder]:
+        """
+        Return the items for a single recommendation row.
 
-        # Folder 2: Editorial curated playlists ("Collections")
-        editorial_items = await self._get_editorial_playlists()
-        if editorial_items:
-            folders.append(
-                RecommendationFolder(
-                    item_id="editorial",
-                    provider=self.instance_id,
-                    name="Collections",
-                    subtitle="Editorial playlists from Zvuk by genre",
-                    translation_key="editorial",
-                    icon="mdi-music-box-multiple",
-                    items=editorial_items,  # type: ignore[arg-type]
-                )
-            )
-
-        return folders
+        :param item_id: The item_id of the row, as returned by get_recommendations.
+        """
+        if item_id == "for_you":
+            return UniqueList(await self._get_for_you_playlists())
+        if item_id == "editorial":
+            return UniqueList(await self._get_editorial_playlists())
+        return UniqueList()
 
     async def browse(self, path: str) -> list[MediaItemType | ItemMapping | BrowseFolder]:
         """

--- a/specs/inprogress/reverse-sync-pr4487.md
+++ b/specs/inprogress/reverse-sync-pr4487.md
@@ -1,0 +1,9 @@
+# Reverse-sync: upstream PR #4487
+
+WIP=1
+
+Ported from music-assistant/server#4487 into `zvuk_music`.
+
+## Summary
+
+_TODO: describe the change._

--- a/tests/test_provider_browse.py
+++ b/tests/test_provider_browse.py
@@ -1,4 +1,4 @@
-"""Tests for ZvukMusicProvider browse, recommendations, and playlist management."""
+"""Tests for ZvukMusicProvider browse and playlist management."""
 
 from __future__ import annotations
 
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 from music_assistant_models.enums import ProviderFeature
-from music_assistant_models.media_items import BrowseFolder, Playlist, RecommendationFolder
+from music_assistant_models.media_items import BrowseFolder, Playlist
 
 from provider.constants import PLAYLIST_TRACK_FETCH_LIMIT
 from provider.provider import ZvukMusicProvider
@@ -48,9 +48,6 @@ def _make_provider() -> Any:
     provider._get_editorial_playlists = AsyncMock(return_value=[])
     # Bind real implementations
     provider.remove_playlist_tracks = ZvukMusicProvider.remove_playlist_tracks.__get__(
-        provider, ZvukMusicProvider
-    )
-    provider.recommendations = ZvukMusicProvider.recommendations.__get__(
         provider, ZvukMusicProvider
     )
     provider.browse = ZvukMusicProvider.browse.__get__(provider, ZvukMusicProvider)
@@ -107,64 +104,6 @@ class TestRemovePlaylistTracks:
         await provider.remove_playlist_tracks("playlist-3", ())
 
         provider.client.update_playlist.assert_awaited_once_with("playlist-3", ["11", "22"])
-
-
-# ---------------------------------------------------------------------------
-# Tests for recommendations()
-# ---------------------------------------------------------------------------
-
-
-class TestRecommendations:
-    """Tests for ZvukMusicProvider.recommendations()."""
-
-    @pytest.mark.asyncio
-    async def test_returns_two_folders_when_both_helpers_have_items(self) -> None:
-        """Two RecommendationFolders are returned when both helpers return playlists."""
-        provider = _make_provider()
-        provider._get_for_you_playlists = AsyncMock(return_value=[_make_playlist("3")])
-        provider._get_editorial_playlists = AsyncMock(return_value=[_make_playlist("99")])
-
-        folders = await provider.recommendations()
-
-        assert len(folders) == 2
-        assert all(isinstance(f, RecommendationFolder) for f in folders)
-        assert folders[0].item_id == "for_you"
-        assert folders[1].item_id == "editorial"
-
-    @pytest.mark.asyncio
-    async def test_omits_for_you_folder_when_helper_returns_empty(self) -> None:
-        """The "Made for you" folder is omitted when _get_for_you_playlists returns []."""
-        provider = _make_provider()
-        provider._get_for_you_playlists = AsyncMock(return_value=[])
-        provider._get_editorial_playlists = AsyncMock(return_value=[_make_playlist("99")])
-
-        folders = await provider.recommendations()
-
-        assert len(folders) == 1
-        assert folders[0].item_id == "editorial"
-
-    @pytest.mark.asyncio
-    async def test_omits_editorial_folder_when_helper_returns_empty(self) -> None:
-        """The "Collections" folder is omitted when _get_editorial_playlists returns []."""
-        provider = _make_provider()
-        provider._get_for_you_playlists = AsyncMock(return_value=[_make_playlist("3")])
-        provider._get_editorial_playlists = AsyncMock(return_value=[])
-
-        folders = await provider.recommendations()
-
-        assert len(folders) == 1
-        assert folders[0].item_id == "for_you"
-
-    @pytest.mark.asyncio
-    async def test_returns_empty_when_both_helpers_return_empty(self) -> None:
-        """An empty list is returned when both helpers have no playlists."""
-        provider = _make_provider()
-        provider._get_for_you_playlists = AsyncMock(return_value=[])
-        provider._get_editorial_playlists = AsyncMock(return_value=[])
-
-        folders = await provider.recommendations()
-
-        assert folders == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_recommendations.py
+++ b/tests/test_recommendations.py
@@ -1,0 +1,92 @@
+"""Test ZvukMusicProvider's two-method recommendations contract."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from music_assistant_models.media_items import Playlist, UniqueList
+
+from provider.provider import ZvukMusicProvider
+
+
+def _make_playlist(item_id: str = "1") -> Playlist:
+    """Return a minimal Playlist mock."""
+    pl = Mock(spec=Playlist)
+    pl.item_id = item_id
+    return pl
+
+
+def _make_provider() -> Any:
+    """Create a ZvukMusicProvider mock with helpers stubbed and the real methods bound."""
+    provider = Mock(spec=ZvukMusicProvider)
+    provider.instance_id = "zvuk_music"
+    provider._get_for_you_playlists = AsyncMock(return_value=[_make_playlist("3")])
+    provider._get_editorial_playlists = AsyncMock(return_value=[_make_playlist("99")])
+    provider.get_recommendations = ZvukMusicProvider.get_recommendations.__get__(
+        provider, ZvukMusicProvider
+    )
+    provider.get_recommendation_items = ZvukMusicProvider.get_recommendation_items.__get__(
+        provider, ZvukMusicProvider
+    )
+    return provider
+
+
+@pytest.mark.asyncio
+async def test_get_recommendations_returns_static_rows_without_backend_calls() -> None:
+    """get_recommendations returns both row descriptors without any backend fetch."""
+    provider = _make_provider()
+
+    result = await provider.get_recommendations()
+
+    provider._get_for_you_playlists.assert_not_awaited()
+    provider._get_editorial_playlists.assert_not_awaited()
+    assert [f.item_id for f in result] == ["for_you", "editorial"]
+    assert all(f.provider == "zvuk_music" for f in result)
+    assert all(len(f.items) == 0 for f in result)
+    for_you, editorial = result
+    assert for_you.name == "Made for you"
+    assert for_you.translation_key == "made_for_you"
+    assert for_you.icon == "mdi-playlist-music"
+    assert editorial.name == "Collections"
+    assert editorial.translation_key == "editorial"
+    assert editorial.icon == "mdi-music-box-multiple"
+    assert editorial.subtitle == "Editorial playlists from Zvuk by genre"
+
+
+@pytest.mark.asyncio
+async def test_get_recommendation_items_for_you_fetches_only_for_you() -> None:
+    """The for_you row triggers only the for-you fetch and returns its playlists."""
+    provider = _make_provider()
+
+    result = await provider.get_recommendation_items("for_you")
+
+    provider._get_for_you_playlists.assert_awaited_once()
+    provider._get_editorial_playlists.assert_not_awaited()
+    assert [item.item_id for item in result] == ["3"]
+
+
+@pytest.mark.asyncio
+async def test_get_recommendation_items_editorial_fetches_only_editorial() -> None:
+    """The editorial row triggers only the editorial fetch and returns its playlists."""
+    provider = _make_provider()
+
+    result = await provider.get_recommendation_items("editorial")
+
+    provider._get_for_you_playlists.assert_not_awaited()
+    provider._get_editorial_playlists.assert_awaited_once()
+    assert [item.item_id for item in result] == ["99"]
+
+
+@pytest.mark.asyncio
+async def test_get_recommendation_items_unknown_id_returns_empty() -> None:
+    """An unknown row item_id returns an empty UniqueList without any backend fetch."""
+    provider = _make_provider()
+
+    result = await provider.get_recommendation_items("bogus")
+
+    provider._get_for_you_playlists.assert_not_awaited()
+    provider._get_editorial_playlists.assert_not_awaited()
+    assert isinstance(result, UniqueList)
+    assert len(result) == 0


### PR DESCRIPTION
Reverse-sync of upstream PR https://github.com/music-assistant/server/pull/4487 into the `zvuk_music` provider.

> ⚠ Patch applied with **conflicts** — `.rej`/markers left in the tree. Resolve them before marking ready.


Original author: @chrisuthe (credited via `Co-authored-by`).

**Maintainer-owned files were NOT touched** — review `VERSION` and `translations/en.json` manually if the upstream change implies a bump.

- [ ] Spec filled in (`specs/inprogress/`)
- [ ] CHANGELOG entry finalized
- [ ] Tests pass locally