### PR TITLE
reverse-sync: Fix providers that could no longer be added (#5053)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,3 +192,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat: add Zvuk Music provider scaffold (manifest, constants, icons)
 - feat: add Zvuk Music API client and model parsers
 - feat: implement ZvukMusicProvider (browse, search, streaming)
+- Reverse-synced upstream PR #5053 (WIP)

--- a/provider/constants.py
+++ b/provider/constants.py
@@ -8,9 +8,6 @@ from typing import Final
 CONF_TOKEN: Final[str] = "token"
 CONF_QUALITY: Final[str] = "quality"
 
-# Actions
-CONF_ACTION_CLEAR_AUTH: Final[str] = "clear_auth"
-
 # API defaults
 DEFAULT_LIMIT: Final[int] = 50
 PLAYLIST_TRACKS_PAGE_SIZE: Final[int] = 50

--- a/provider/provider.py
+++ b/provider/provider.py
@@ -60,9 +60,27 @@ class ZvukMusicProvider(MusicProvider):
             raise ProviderUnavailableError("Provider not initialized")
         return self._client
 
+<<<<<<< ours
+=======
+    async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
+        """Return Config entries to configure this provider."""
+        return (
+            CONF_ENTRY_UNOFFICIAL_PROVIDER,
+            ConfigEntry(
+                key=CONF_QUALITY,
+                type=ConfigEntryType.STRING,
+                options=[
+                    ConfigValueOption(QUALITY_HIGH),
+                    ConfigValueOption(QUALITY_LOSSLESS),
+                ],
+                default_value=QUALITY_HIGH,
+            ),
+        )
+
+>>>>>>> theirs
     async def handle_async_init(self) -> None:
         """Handle async initialization of the provider."""
-        token = self.config.get_value(CONF_TOKEN)
+        token = self.get_setup_value(CONF_TOKEN)
         if not token:
             raise LoginFailed("No Zvuk Music token provided")
 
@@ -555,7 +573,7 @@ class ZvukMusicProvider(MusicProvider):
             ),
         }
         if is_zvuk:
-            token = self.config.get_value(CONF_TOKEN)
+            token = self.get_setup_value(CONF_TOKEN)
             if not token:
                 return str(path)
             headers["X-Auth-Token"] = str(token)

--- a/provider/setup_flow.py
+++ b/provider/setup_flow.py
@@ -1,0 +1,43 @@
+"""Setup flow for the Zvuk Music provider."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import TYPE_CHECKING
+
+from music_assistant_models.config_entries import ConfigEntry
+from music_assistant_models.enums import ConfigEntryType
+
+from music_assistant.constants import CONF_ENTRY_UNOFFICIAL_PROVIDER
+from music_assistant.models.setup_flow import SetupFlowError
+
+from .constants import CONF_TOKEN
+
+if TYPE_CHECKING:
+    from music_assistant.models.setup_flow import SetupSession
+
+_ENTRIES = (
+    CONF_ENTRY_UNOFFICIAL_PROVIDER,
+    ConfigEntry(key=CONF_TOKEN, type=ConfigEntryType.SECURE_STRING, required=True),
+)
+
+
+async def run_setup(session: SetupSession) -> None:
+    """
+    Run the setup flow: collect the Zvuk auth token and create the provider.
+
+    :param session: The setup session driving the flow.
+    """
+    errors: dict[str, str] | None = None
+    setup_data = dict(session.context.setup_data)
+    while True:
+        entries = [
+            replace(entry, value=setup_data.get(entry.key, entry.value)) for entry in _ENTRIES
+        ]
+        submitted = await session.form(entries, step_id="user", errors=errors, last_step=True)
+        setup_data.update(submitted)
+        try:
+            await session.finish(setup_data)
+            return
+        except SetupFlowError as err:
+            errors = {"base": err.translation_key or str(err)}

--- a/provider/strings.json
+++ b/provider/strings.json
@@ -4,10 +4,6 @@
       "label": "Zvuk Music Token",
       "description": "Enter your Zvuk Music X-Auth-Token. See the documentation for how to obtain it."
     },
-    "clear_auth": {
-      "label": "[%key:common::config_entries::clear_auth::label%]",
-      "description": "[%key:common::config_entries::clear_auth::description%]"
-    },
     "quality": {
       "label": "Audio quality",
       "description": "Select preferred audio quality.",
@@ -15,6 +11,12 @@
         "high": "High (320 kbps)",
         "lossless": "Lossless (FLAC)"
       }
+    }
+  },
+  "setup_flow": {
+    "user": {
+      "title": "Connect to Zvuk",
+      "description": "Music Assistant needs your personal Zvuk X-Auth-Token to reach your account and library."
     }
   },
   "media": {

--- a/specs/inprogress/reverse-sync-pr5053.md
+++ b/specs/inprogress/reverse-sync-pr5053.md
@@ -1,0 +1,9 @@
+# Reverse-sync: upstream PR #5053
+
+WIP=1
+
+Ported from music-assistant/server#5053 into `zvuk_music`.
+
+## Summary
+
+_TODO: describe the change._


### PR DESCRIPTION
Reverse-sync of upstream PR https://github.com/music-assistant/server/pull/5053 into the `zvuk_music` provider.

> ⚠ Patch applied with **conflicts** — `.rej`/markers left in the tree. Resolve them before marking ready.


Original author: @marcelveldt (credited via `Co-authored-by`).

**Maintainer-owned files were NOT touched** — review `VERSION` and `translations/en.json` manually if the upstream change implies a bump.

- [ ] Spec filled in (`specs/inprogress/`)
- [ ] CHANGELOG entry finalized
- [ ] Tests pass locally