### PR TITLE
reverse-sync: Name the token in the KION and Zvuk sign-in error (#5058)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,3 +192,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat: add Zvuk Music provider scaffold (manifest, constants, icons)
 - feat: add Zvuk Music API client and model parsers
 - feat: implement ZvukMusicProvider (browse, search, streaming)
+- Reverse-synced upstream PR #5058 (WIP)

--- a/provider/strings.json
+++ b/provider/strings.json
@@ -17,6 +17,18 @@
       }
     }
   },
+<<<<<<< ours
+=======
+  "setup_flow": {
+    "user": {
+      "title": "Connect to Zvuk",
+      "description": "Music Assistant needs your personal Zvuk X-Auth-Token to reach your account and library."
+    }
+  },
+  "errors": {
+    "login_failed": "Could not sign in to Zvuk Music with this token. See the documentation for how to obtain a fresh X-Auth-Token."
+  },
+>>>>>>> theirs
   "media": {
     "recommendations": {
       "editorial": {

--- a/specs/inprogress/reverse-sync-pr5058.md
+++ b/specs/inprogress/reverse-sync-pr5058.md
@@ -1,0 +1,9 @@
+# Reverse-sync: upstream PR #5058
+
+WIP=1
+
+Ported from music-assistant/server#5058 into `zvuk_music`.
+
+## Summary
+
+_TODO: describe the change._


### PR DESCRIPTION
Reverse-sync of upstream PR https://github.com/music-assistant/server/pull/5058 into the `zvuk_music` provider.

> ⚠ Patch applied with **conflicts** — `.rej`/markers left in the tree. Resolve them before marking ready.


Original author: @marcelveldt (credited via `Co-authored-by`).

**Maintainer-owned files were NOT touched** — review `VERSION` and `translations/en.json` manually if the upstream change implies a bump.

- [ ] Spec filled in (`specs/inprogress/`)
- [ ] CHANGELOG entry finalized
- [ ] Tests pass locally