### PR TITLE
Fix false-positive upstream synchronization failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - New provider instances can be configured through the current Music Assistant setup flow, and rejected tokens now show a Zvuk-specific sign-in message.
+- Upstream synchronization no longer misclassifies the already reverse-ported setup-flow and recommendation changes as unmerged upstream work.
 
 ## [1.8.3] - 2026-07-16
 

--- a/provider/provider.py
+++ b/provider/provider.py
@@ -71,7 +71,7 @@ class ZvukMusicProvider(MusicProvider):
         return self._client
 
     async def get_config_entries(self) -> tuple[ConfigEntry, ...]:
-        """Return config entries for provider options."""
+        """Return Config entries to configure this provider."""
         return (
             CONF_ENTRY_UNOFFICIAL_PROVIDER,
             ConfigEntry(
@@ -123,6 +123,8 @@ class ZvukMusicProvider(MusicProvider):
             provider=self.instance_id,
             name=name,
         )
+
+    # Search
 
     @use_cache(3600 * 24 * 14)
     async def search(
@@ -183,6 +185,8 @@ class ZvukMusicProvider(MusicProvider):
 
         return result
 
+    # Get single items
+
     @use_cache(3600 * 24 * 30)
     async def get_artist(self, prov_artist_id: str) -> Artist:
         """
@@ -238,6 +242,8 @@ class ZvukMusicProvider(MusicProvider):
         if not playlist:
             raise MediaNotFoundError(f"Playlist {prov_playlist_id} not found")
         return parse_playlist(self, playlist)
+
+    # Get related items
 
     @use_cache(3600 * 24 * 30, allow_expired_cache=True)
     async def get_album_tracks(self, prov_album_id: str) -> list[Track]:
@@ -373,6 +379,8 @@ class ZvukMusicProvider(MusicProvider):
 
         return result[:limit]
 
+    # Library methods
+
     async def get_library_artists(self) -> AsyncGenerator[Artist]:
         """Retrieve library artists from Zvuk Music."""
         collection = await self.client.get_collection()
@@ -427,10 +435,11 @@ class ZvukMusicProvider(MusicProvider):
 
     async def get_recommendations(self) -> list[RecommendationFolder]:
         """
-        Return the available recommendation rows without loading their items.
+        Return the available recommendation rows, without items.
 
-        The items for each row are fetched separately by
-        ``get_recommendation_items``.
+        Two rows:
+        - "for_you" ("Made for you"): Zvuk's AI-generated personalized playlists.
+        - "editorial" ("Collections"): Editorial genre-themed curated playlists.
         """
         return [
             RecommendationFolder(
@@ -454,9 +463,9 @@ class ZvukMusicProvider(MusicProvider):
         self, item_id: str
     ) -> UniqueList[MediaItemType | ItemMapping | BrowseFolder]:
         """
-        Return the items for one recommendation row.
+        Return the items for a single recommendation row.
 
-        :param item_id: The row ID returned by ``get_recommendations``.
+        :param item_id: The item_id of the row, as returned by get_recommendations.
         """
         if item_id == "for_you":
             return UniqueList(await self._get_for_you_playlists())
@@ -592,6 +601,8 @@ class ZvukMusicProvider(MusicProvider):
             self.logger.debug("Failed to resolve image %s: %s", path, err)
         return str(path)
 
+    # Library edit methods
+
     async def library_add(self, item: MediaItemType) -> bool:
         """
         Add item to library.
@@ -630,6 +641,8 @@ class ZvukMusicProvider(MusicProvider):
         if media_type == MediaType.PLAYLIST:
             return await self.client.unlike_playlist(prov_item_id)
         return False
+
+    # Playlist management
 
     async def create_playlist(self, name: str, media_types: set[MediaType]) -> Playlist:
         """
@@ -672,6 +685,8 @@ class ZvukMusicProvider(MusicProvider):
             str(t.id) for i, t in enumerate(simple_tracks) if t.id and i not in remove_positions
         ]
         await self.client.update_playlist(prov_playlist_id, remaining_ids)
+
+    # Streaming
 
     async def get_stream_details(
         self, item_id: str, media_type: MediaType = MediaType.TRACK

--- a/provider/setup_flow.py
+++ b/provider/setup_flow.py
@@ -24,7 +24,7 @@ _ENTRIES = (
 
 async def run_setup(session: SetupSession) -> None:
     """
-    Run the setup flow and persist the submitted Zvuk token.
+    Run the setup flow: collect the Zvuk auth token and create the provider.
 
     :param session: The setup session driving the flow.
     """

--- a/tests/test_provider_browse.py
+++ b/tests/test_provider_browse.py
@@ -1,4 +1,4 @@
-"""Tests for ZvukMusicProvider browse, recommendations, and playlist management."""
+"""Tests for ZvukMusicProvider browse and playlist management."""
 
 from __future__ import annotations
 

--- a/tests/test_recommendation_contract.py
+++ b/tests/test_recommendation_contract.py
@@ -1,0 +1,26 @@
+"""Provider-side regression tests for the recommendation result contract."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from music_assistant_models.media_items import UniqueList
+
+from provider.provider import ZvukMusicProvider
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("item_id", ["for_you", "editorial"])
+async def test_successful_recommendation_rows_return_unique_lists(item_id: str) -> None:
+    """Successful recommendation rows preserve the ``UniqueList`` contract."""
+    provider = Mock(spec=ZvukMusicProvider)
+    provider._get_for_you_playlists = AsyncMock(return_value=[])
+    provider._get_editorial_playlists = AsyncMock(return_value=[])
+    provider.get_recommendation_items = ZvukMusicProvider.get_recommendation_items.__get__(
+        provider, ZvukMusicProvider
+    )
+
+    result = await provider.get_recommendation_items(item_id)
+
+    assert isinstance(result, UniqueList)

--- a/tests/test_recommendations.py
+++ b/tests/test_recommendations.py
@@ -1,4 +1,4 @@
-"""Tests for lazy Zvuk recommendation rows."""
+"""Test ZvukMusicProvider's two-method recommendations contract."""
 
 from __future__ import annotations
 
@@ -6,26 +6,24 @@ from typing import Any
 from unittest.mock import AsyncMock, Mock
 
 import pytest
-from music_assistant_models.enums import ProviderFeature
 from music_assistant_models.media_items import Playlist, UniqueList
 
 from provider.provider import ZvukMusicProvider
 
 
-def _playlist(item_id: str) -> Playlist:
-    """Return a minimal playlist with a stable item ID."""
-    playlist = Mock(spec=Playlist)
-    playlist.item_id = item_id
-    return playlist
+def _make_playlist(item_id: str = "1") -> Playlist:
+    """Return a minimal Playlist mock."""
+    pl = Mock(spec=Playlist)
+    pl.item_id = item_id
+    return pl
 
 
-def _provider() -> Any:
-    """Create a provider mock bound to the real recommendation methods."""
+def _make_provider() -> Any:
+    """Create a ZvukMusicProvider mock with helpers stubbed and the real methods bound."""
     provider = Mock(spec=ZvukMusicProvider)
     provider.instance_id = "zvuk_music"
-    provider.supported_features = {ProviderFeature.RECOMMENDATIONS}
-    provider._get_for_you_playlists = AsyncMock(return_value=[_playlist("3")])
-    provider._get_editorial_playlists = AsyncMock(return_value=[_playlist("99")])
+    provider._get_for_you_playlists = AsyncMock(return_value=[_make_playlist("3")])
+    provider._get_editorial_playlists = AsyncMock(return_value=[_make_playlist("99")])
     provider.get_recommendations = ZvukMusicProvider.get_recommendations.__get__(
         provider, ZvukMusicProvider
     )
@@ -36,48 +34,59 @@ def _provider() -> Any:
 
 
 @pytest.mark.asyncio
-async def test_recommendation_rows_are_static_and_do_not_fetch_items() -> None:
-    """Row discovery returns descriptors without loading their playlists."""
-    provider = _provider()
+async def test_get_recommendations_returns_static_rows_without_backend_calls() -> None:
+    """get_recommendations returns both row descriptors without any backend fetch."""
+    provider = _make_provider()
 
-    rows = await provider.get_recommendations()
-
-    provider._get_for_you_playlists.assert_not_awaited()
-    provider._get_editorial_playlists.assert_not_awaited()
-    assert [row.item_id for row in rows] == ["for_you", "editorial"]
-    assert all(len(row.items) == 0 for row in rows)
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    ("item_id", "expected_id", "called_helper", "idle_helper"),
-    [
-        ("for_you", "3", "_get_for_you_playlists", "_get_editorial_playlists"),
-        ("editorial", "99", "_get_editorial_playlists", "_get_for_you_playlists"),
-    ],
-)
-async def test_recommendation_items_fetch_only_requested_row(
-    item_id: str, expected_id: str, called_helper: str, idle_helper: str
-) -> None:
-    """Loading one row leaves the other row's backend idle."""
-    provider = _provider()
-
-    items = await provider.get_recommendation_items(item_id)
-
-    getattr(provider, called_helper).assert_awaited_once()
-    getattr(provider, idle_helper).assert_not_awaited()
-    assert isinstance(items, UniqueList)
-    assert [item.item_id for item in items] == [expected_id]
-
-
-@pytest.mark.asyncio
-async def test_unknown_recommendation_row_is_empty_without_backend_calls() -> None:
-    """Unknown row IDs produce an empty result without backend traffic."""
-    provider = _provider()
-
-    items = await provider.get_recommendation_items("unknown")
+    result = await provider.get_recommendations()
 
     provider._get_for_you_playlists.assert_not_awaited()
     provider._get_editorial_playlists.assert_not_awaited()
-    assert isinstance(items, UniqueList)
-    assert not items
+    assert [f.item_id for f in result] == ["for_you", "editorial"]
+    assert all(f.provider == "zvuk_music" for f in result)
+    assert all(len(f.items) == 0 for f in result)
+    for_you, editorial = result
+    assert for_you.name == "Made for you"
+    assert for_you.translation_key == "made_for_you"
+    assert for_you.icon == "mdi-playlist-music"
+    assert editorial.name == "Collections"
+    assert editorial.translation_key == "editorial"
+    assert editorial.icon == "mdi-music-box-multiple"
+    assert editorial.subtitle == "Editorial playlists from Zvuk by genre"
+
+
+@pytest.mark.asyncio
+async def test_get_recommendation_items_for_you_fetches_only_for_you() -> None:
+    """The for_you row triggers only the for-you fetch and returns its playlists."""
+    provider = _make_provider()
+
+    result = await provider.get_recommendation_items("for_you")
+
+    provider._get_for_you_playlists.assert_awaited_once()
+    provider._get_editorial_playlists.assert_not_awaited()
+    assert [item.item_id for item in result] == ["3"]
+
+
+@pytest.mark.asyncio
+async def test_get_recommendation_items_editorial_fetches_only_editorial() -> None:
+    """The editorial row triggers only the editorial fetch and returns its playlists."""
+    provider = _make_provider()
+
+    result = await provider.get_recommendation_items("editorial")
+
+    provider._get_for_you_playlists.assert_not_awaited()
+    provider._get_editorial_playlists.assert_awaited_once()
+    assert [item.item_id for item in result] == ["99"]
+
+
+@pytest.mark.asyncio
+async def test_get_recommendation_items_unknown_id_returns_empty() -> None:
+    """An unknown row item_id returns an empty UniqueList without any backend fetch."""
+    provider = _make_provider()
+
+    result = await provider.get_recommendation_items("bogus")
+
+    provider._get_for_you_playlists.assert_not_awaited()
+    provider._get_editorial_playlists.assert_not_awaited()
+    assert isinstance(result, UniqueList)
+    assert len(result) == 0


### PR DESCRIPTION
## Summary

- restore the canonical upstream text and tests for the already reverse-ported setup-flow and recommendation changes
- keep provider-private methods in the repository-required order without bypassing the upstream guard
- add a provider-side regression test for the `UniqueList` recommendation result contract

## Root cause

The sync preflight compares upstream edits against the provider repository text. The functionality had already been reverse-ported, but local editorial rewrites and reordered tests made those edits appear missing, so the guard reported four false-positive upstream-ahead files.

## Impact

The official preflight now recognizes the reverse-port as present. Runtime behavior is unchanged; the additional regression test preserves the successful recommendation result type.

## Validation

- `pytest -q`: 132 passed
- `pre-commit run --all-files`: all hooks passed
- `check_upstream_ahead.py --domain zvuk_music --provider-path provider/`: `Provider repo is in sync with upstream provider path.`
- independent final review: no Critical, Important, or Minor findings
