### PR TITLE
reverse-sync: Stop a library item a provider cannot read from being removed from the library (#5861)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -207,4 +207,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat: add Zvuk Music provider scaffold (manifest, constants, icons)
 - feat: add Zvuk Music API client and model parsers
 - feat: implement ZvukMusicProvider (browse, search, streaming)
-- Reverse-synced upstream PR #5861 (WIP)
+- fix: retain library items that cannot be parsed by the provider

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -207,3 +207,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat: add Zvuk Music provider scaffold (manifest, constants, icons)
 - feat: add Zvuk Music API client and model parsers
 - feat: implement ZvukMusicProvider (browse, search, streaming)
+- Reverse-synced upstream PR #5861 (WIP)

--- a/provider/provider.py
+++ b/provider/provider.py
@@ -388,7 +388,7 @@ class ZvukMusicProvider(MusicProvider):
             return
         ids = [str(item.id) for item in collection.artists if item.id]
         async for artist in self._iter_batched(
-            ids, self.client.get_artists, parse_artist, "artist"
+            ids, self.client.get_artists, parse_artist, MediaType.ARTIST
         ):
             yield artist
 
@@ -398,7 +398,9 @@ class ZvukMusicProvider(MusicProvider):
         if not collection or not collection.releases:
             return
         ids = [str(item.id) for item in collection.releases if item.id]
-        async for album in self._iter_batched(ids, self.client.get_releases, parse_album, "album"):
+        async for album in self._iter_batched(
+            ids, self.client.get_releases, parse_album, MediaType.ALBUM
+        ):
             yield album
 
     async def get_library_tracks(self) -> AsyncGenerator[Track]:
@@ -407,7 +409,9 @@ class ZvukMusicProvider(MusicProvider):
         if not collection or not collection.tracks:
             return
         ids = [str(item.id) for item in collection.tracks if item.id]
-        async for track in self._iter_batched(ids, self.client.get_tracks, parse_track, "track"):
+        async for track in self._iter_batched(
+            ids, self.client.get_tracks, parse_track, MediaType.TRACK
+        ):
             yield track
 
     async def get_library_playlists(self) -> AsyncGenerator[Playlist]:
@@ -421,7 +425,7 @@ class ZvukMusicProvider(MusicProvider):
         if collection_items:
             ids = [str(item.id) for item in collection_items if item.id]
             async for playlist in self._iter_batched(
-                ids, self.client.get_playlists, parse_playlist, "playlist"
+                ids, self.client.get_playlists, parse_playlist, MediaType.PLAYLIST
             ):
                 yield playlist
 
@@ -431,7 +435,7 @@ class ZvukMusicProvider(MusicProvider):
             try:
                 yield parse_playlist(self, simple_pl)
             except InvalidDataError as err:
-                self.logger.debug("Error parsing synthesis playlist: %s", err)
+                self.report_skipped_sync_item(MediaType.PLAYLIST, str(simple_pl.id), err)
 
     async def get_recommendations(self) -> list[RecommendationFolder]:
         """
@@ -785,7 +789,7 @@ class ZvukMusicProvider(MusicProvider):
         ids: list[str],
         fetcher: Any,
         parser: Any,
-        item_type: str,
+        media_type: MediaType,
     ) -> AsyncGenerator[Any]:
         """
         Yield parsed items by fetching ``ids`` in batches of DEFAULT_LIMIT.
@@ -793,16 +797,27 @@ class ZvukMusicProvider(MusicProvider):
         :param ids: List of item IDs to fetch.
         :param fetcher: Async callable that accepts a list of IDs and returns a list of raw items.
         :param parser: Callable(provider, raw_item) → MA media item.
-        :param item_type: Human-readable type name for debug log messages.
+        :param media_type: Media type of the items, for skip reporting.
         """
         for i in range(0, len(ids), DEFAULT_LIMIT):
             batch = ids[i : i + DEFAULT_LIMIT]
             items = await fetcher(batch)
+            fetched_ids: set[str] = set()
             for item in items:
+                fetched_ids.add(str(item.id))
                 try:
                     yield parser(self, item)
                 except InvalidDataError as err:
-                    self.logger.debug("Error parsing library %s: %s", item_type, err)
+                    self.report_skipped_sync_item(media_type, str(item.id), err)
+            # the id's come from the user's own collection, so anything the fetch left out
+            # (a whole batch is dropped when it raises NotFound) is still in the library
+            for missing_id in batch:
+                if missing_id not in fetched_ids:
+                    self.report_skipped_sync_item(
+                        media_type,
+                        missing_id,
+                        MediaNotFoundError(f"Zvuk did not return {media_type.value} {missing_id}"),
+                    )
 
     async def _get_for_you_playlists(self) -> list[Playlist]:
         """Fetch and parse Zvuk's personalized synthesis playlists («Плейлисты для вас»)."""

--- a/specs/inprogress/reverse-sync-pr5861.md
+++ b/specs/inprogress/reverse-sync-pr5861.md
@@ -1,0 +1,9 @@
+# Reverse-sync: upstream PR #5861
+
+WIP=1
+
+Ported from music-assistant/server#5861 into `zvuk_music`.
+
+## Summary
+
+_TODO: describe the change._

--- a/specs/inprogress/reverse-sync-pr5861.md
+++ b/specs/inprogress/reverse-sync-pr5861.md
@@ -1,9 +1,8 @@
 # Reverse-sync: upstream PR #5861
 
-WIP=1
-
 Ported from music-assistant/server#5861 into `zvuk_music`.
 
 ## Summary
 
-_TODO: describe the change._
+Retains a library item when parsing it fails but its stable provider identifier
+is still available.

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from music_assistant_models.enums import MediaType
 from music_assistant_models.errors import InvalidDataError
 
 from music_assistant.providers.zvuk_music.constants import DEFAULT_LIMIT
@@ -85,7 +86,7 @@ class TestGetLibraryArtists:
         collection.artists = [_make_item(1), _make_item(2)]
         provider.client.get_collection = AsyncMock(return_value=collection)
 
-        raw_1, raw_2 = Mock(), Mock()
+        raw_1, raw_2 = _make_item(1), _make_item(2)
         provider.client.get_artists = AsyncMock(return_value=[raw_1, raw_2])
 
         parsed_1, parsed_2 = Mock(), Mock()
@@ -96,26 +97,29 @@ class TestGetLibraryArtists:
         assert results == [parsed_1, parsed_2]
 
     @pytest.mark.asyncio
-    async def test_invalid_data_error_is_logged_and_item_skipped(self) -> None:
-        """InvalidDataError from parse_artist is logged and the item is skipped."""
+    async def test_invalid_data_error_is_skipped(self) -> None:
+        """InvalidDataError from parse_artist is reported and the item is skipped."""
         provider = _make_provider()
         collection = Mock()
         collection.artists = [_make_item(1), _make_item(2)]
         provider.client.get_collection = AsyncMock(return_value=collection)
 
-        raw_1, raw_2 = Mock(), Mock()
+        raw_1, raw_2 = _make_item(1), _make_item(2)
         provider.client.get_artists = AsyncMock(return_value=[raw_1, raw_2])
 
         parsed_2 = Mock()
+        err = InvalidDataError("bad data")
 
         with patch(
             f"{_PROVIDER_MODULE}.parse_artist",
-            side_effect=[InvalidDataError("bad data"), parsed_2],
+            side_effect=[err, parsed_2],
         ):
             results = [a async for a in provider.get_library_artists()]
 
         assert results == [parsed_2]
-        cast("Mock", provider.logger.debug).assert_called()
+        provider.report_skipped_sync_item.assert_called_once_with(
+            MediaType.ARTIST, str(raw_1.id), err
+        )
 
     @pytest.mark.asyncio
     async def test_large_collection_fetches_multiple_batches(self) -> None:
@@ -164,7 +168,7 @@ class TestGetLibraryAlbums:
         collection.releases = [_make_item(10), _make_item(20)]
         provider.client.get_collection = AsyncMock(return_value=collection)
 
-        raw_1, raw_2 = Mock(), Mock()
+        raw_1, raw_2 = _make_item(10), _make_item(20)
         provider.client.get_releases = AsyncMock(return_value=[raw_1, raw_2])
 
         parsed_1, parsed_2 = Mock(), Mock()
@@ -176,18 +180,20 @@ class TestGetLibraryAlbums:
 
     @pytest.mark.asyncio
     async def test_invalid_data_error_is_skipped(self) -> None:
-        """InvalidDataError from parse_album causes the item to be skipped."""
+        """InvalidDataError from parse_album is reported and the item is skipped."""
         provider = _make_provider()
         collection = Mock()
         collection.releases = [_make_item(10)]
         provider.client.get_collection = AsyncMock(return_value=collection)
-        provider.client.get_releases = AsyncMock(return_value=[Mock()])
+        raw = _make_item(10)
+        provider.client.get_releases = AsyncMock(return_value=[raw])
 
-        with patch(f"{_PROVIDER_MODULE}.parse_album", side_effect=InvalidDataError("bad release")):
+        err = InvalidDataError("bad release")
+        with patch(f"{_PROVIDER_MODULE}.parse_album", side_effect=err):
             results = [a async for a in provider.get_library_albums()]
 
         assert results == []
-        cast("Mock", provider.logger.debug).assert_called()
+        provider.report_skipped_sync_item.assert_called_once_with(MediaType.ALBUM, str(raw.id), err)
 
 
 # ---------------------------------------------------------------------------
@@ -216,7 +222,7 @@ class TestGetLibraryTracks:
         collection.tracks = [_make_item(100), _make_item(200)]
         provider.client.get_collection = AsyncMock(return_value=collection)
 
-        raw_1, raw_2 = Mock(), Mock()
+        raw_1, raw_2 = _make_item(100), _make_item(200)
         provider.client.get_tracks = AsyncMock(return_value=[raw_1, raw_2])
 
         parsed_1, parsed_2 = Mock(), Mock()
@@ -273,7 +279,7 @@ class TestGetLibraryPlaylists:
         """User playlists are fetched in batch and parsed."""
         provider = _make_provider()
         provider.client.get_user_playlists = AsyncMock(return_value=[_make_item(1), _make_item(2)])
-        raw_1, raw_2 = Mock(), Mock()
+        raw_1, raw_2 = _make_item(1), _make_item(2)
         provider.client.get_playlists = AsyncMock(return_value=[raw_1, raw_2])
         provider.client.get_short_playlists = AsyncMock(return_value=[])
 
@@ -304,31 +310,35 @@ class TestGetLibraryPlaylists:
 
     @pytest.mark.asyncio
     async def test_synthesis_invalid_data_error_is_skipped(self) -> None:
-        """InvalidDataError from a synthesis playlist parser is skipped."""
+        """InvalidDataError from a synthesis playlist parser is reported and skipped."""
         provider = _make_provider()
         # Need at least one user playlist so the method doesn't return early
         provider.client.get_user_playlists = AsyncMock(return_value=[_make_item(1)])
-        provider.client.get_playlists = AsyncMock(return_value=[Mock()])
-        provider.client.get_short_playlists = AsyncMock(return_value=[Mock()])
+        provider.client.get_playlists = AsyncMock(return_value=[_make_item(1)])
+        raw_synth = Mock()
+        provider.client.get_short_playlists = AsyncMock(return_value=[raw_synth])
 
         # First call (user playlist) succeeds; second call (synthesis) raises
         good_parsed = Mock()
+        err = InvalidDataError("bad synth")
         with patch(
             f"{_PROVIDER_MODULE}.parse_playlist",
-            side_effect=[good_parsed, InvalidDataError("bad synth")],
+            side_effect=[good_parsed, err],
         ):
             results = [p async for p in provider.get_library_playlists()]
 
         # User playlist is yielded; synthesis item is skipped
         assert results == [good_parsed]
-        cast("Mock", provider.logger.debug).assert_called()
+        provider.report_skipped_sync_item.assert_called_once_with(
+            MediaType.PLAYLIST, str(raw_synth.id), err
+        )
 
     @pytest.mark.asyncio
     async def test_invalid_data_error_in_user_playlist_is_skipped(self) -> None:
         """InvalidDataError from parse_playlist on a user playlist is skipped."""
         provider = _make_provider()
         provider.client.get_user_playlists = AsyncMock(return_value=[_make_item(1), _make_item(2)])
-        raw_1, raw_2 = Mock(), Mock()
+        raw_1, raw_2 = _make_item(1), _make_item(2)
         provider.client.get_playlists = AsyncMock(return_value=[raw_1, raw_2])
         provider.client.get_short_playlists = AsyncMock(return_value=[])
 
@@ -341,3 +351,44 @@ class TestGetLibraryPlaylists:
             results = [p async for p in provider.get_library_playlists()]
 
         assert results == [good_parsed]
+
+
+class TestBatchFetchGaps:
+    """Tests for id's a batch fetch does not return."""
+
+    @pytest.mark.asyncio
+    async def test_id_the_fetch_left_out_is_reported(self) -> None:
+        """
+        An id the batch fetch did not return is reported instead of looking removed.
+
+        The fetch returns an empty list for a batch it cannot find, which would otherwise
+        drop every item in that batch out of the library.
+        """
+        provider = _make_provider()
+        collection = Mock()
+        collection.artists = [_make_item(1), _make_item(2)]
+        provider.client.get_collection = AsyncMock(return_value=collection)
+        provider.client.get_artists = AsyncMock(return_value=[])
+
+        with patch(f"{_PROVIDER_MODULE}.parse_artist"):
+            results = [a async for a in provider.get_library_artists()]
+
+        assert results == []
+        reported = {call.args[1] for call in provider.report_skipped_sync_item.call_args_list}
+        assert reported == {"1", "2"}
+
+    @pytest.mark.asyncio
+    async def test_id_the_fetch_returned_is_not_reported(self) -> None:
+        """An item that came back fine is not reported as missing."""
+        provider = _make_provider()
+        collection = Mock()
+        collection.artists = [_make_item(1), _make_item(2)]
+        provider.client.get_collection = AsyncMock(return_value=collection)
+        provider.client.get_artists = AsyncMock(return_value=[_make_item(1)])
+
+        with patch(f"{_PROVIDER_MODULE}.parse_artist"):
+            results = [a async for a in provider.get_library_artists()]
+
+        assert len(results) == 1
+        reported = {call.args[1] for call in provider.report_skipped_sync_item.call_args_list}
+        assert reported == {"2"}


### PR DESCRIPTION
Reverse-sync of upstream PR https://github.com/music-assistant/server/pull/5861 into the `zvuk_music` provider.

Original author: @marcelveldt (credited via `Co-authored-by`).

**Maintainer-owned files were NOT touched** — review `VERSION` and `translations/en.json` manually if the upstream change implies a bump.

- [ ] Spec filled in (`specs/inprogress/`)
- [ ] CHANGELOG entry finalized
- [ ] Tests pass locally